### PR TITLE
Feature: Game-over mine reveal, scoring, and scoreboard

### DIFF
--- a/docs/plans/2026-03-01-game-over-score-scoreboard-design.md
+++ b/docs/plans/2026-03-01-game-over-score-scoreboard-design.md
@@ -1,0 +1,174 @@
+# Game Over Reveal, Score, and Scoreboard Design
+
+## Summary
+
+Three features that bring Mimesweeper closer to classic
+Minesweeper behavior and add replayability:
+
+1. Reveal all mines when the player loses
+2. Calculate a score based on board size and elapsed time
+3. Persist a top-10 scoreboard per difficulty in localStorage
+
+## Feature 1: Reveal Mines on Game Over
+
+### Problem
+
+When a player clicks a mine and loses, only the clicked
+mine appears. The player cannot see where the other mines
+were, which removes the "aha" moment that classic
+Minesweeper provides.
+
+### Design
+
+**GameSquare additions** (`types.d.ts`):
+
+- `clickedMime?: boolean` — marks the mine the player
+  clicked (the one that caused the loss)
+- `wrongFlag?: boolean` — marks non-mine squares that
+  the player flagged incorrectly
+
+**Reducer changes** (`gameReducer.ts`):
+
+When `processSquareClick` returns `lost: true`:
+
+1. Set `clickedMime: true` on the detonated square.
+2. Iterate all squares in the cloned game map:
+   - Mine, unopened, unflagged: set `opened: true`
+     (reveals the mine).
+   - Non-mine, flagged: set `wrongFlag: true`
+     (marks the mistake).
+   - Flagged mines stay flagged (correct placement).
+
+**Square.tsx rendering** — three visual states on
+game-over:
+
+| State | Background | Icon |
+|-------|-----------|------|
+| Clicked mine (`clickedMime`) | Red (#f80000) | Mime image |
+| Revealed mine (not clicked) | White (#FFFFFF) | Mime image |
+| Wrong flag (`wrongFlag`) | White | Flag + X overlay |
+
+Correctly flagged mines keep their flag appearance.
+
+On win: no reveal needed. The player already deduced
+every mine location.
+
+## Feature 2: Score Mechanism
+
+### Motivation
+
+No incentive to replay or improve. The timer runs but
+produces no score.
+
+### Score Design
+
+**Formula**:
+
+```text
+baseScore = 1000 + (1000 x 5 x difficultyMultiplier)
+
+  S  → multiplier 0 → base 1000
+  M  → multiplier 1 → base 6000
+  L  → multiplier 2 → base 11000
+  XL → multiplier 3 → base 16000
+
+score = max(0, baseScore - (elapsedSeconds x 5))
+```
+
+The score decrements by 5 each second and bottoms at 0.
+
+**State changes** (`GameState` in `types.d.ts`):
+
+- Add `score: number`.
+
+**Reducer changes** (`gameReducer.ts`):
+
+- `START_GAME`: compute and store `score` from the
+  selected difficulty.
+- `TICK`: `score = Math.max(0, state.score - 5)`.
+
+**Utility** (`src/utils/score.ts`):
+
+- `getBaseScore(gridSize: GridSize): number` — maps
+  grid size to base score.
+
+**Display**: Show the final score as large text in the
+win overlay.
+
+## Feature 3: Top 10 Scoreboard
+
+### Persistence Gap
+
+No persistent record of achievement. Scores vanish on
+page refresh.
+
+### Scoreboard Design
+
+**Data model** (`types.d.ts`):
+
+```typescript
+interface ScoreEntry {
+  name: string;
+  score: number;
+}
+type DifficultyKey = "S" | "M" | "L" | "XL";
+type ScoreboardData = Record<DifficultyKey, ScoreEntry[]>;
+```
+
+**Storage**: localStorage key `"mimesweeper-scoreboard"`.
+
+**Default data**: each difficulty pre-populated with 10
+entries of `{ name: "JMS", score: 100 }`.
+
+**Hook** (`src/hooks/useScoreboard.ts`):
+
+- `scores` — current `ScoreboardData`
+- `addScore(difficulty, name, score)` — insert into
+  sorted list, trim to 10, persist
+- `isHighScore(difficulty, score)` — true if the score
+  qualifies for the top 10
+- `getScores(difficulty)` — sorted entries for one
+  difficulty
+
+**Scoreboard component** (`src/Scoreboard.tsx`):
+
+- DOM overlay matching existing overlay patterns
+- Difficulty tabs or selector to switch between lists
+- Numbered list: rank, name, score
+- Accessible via a "Scoreboard" button in the game
+  header
+
+**Win overlay changes** (`src/App.tsx`):
+
+- Show final score prominently.
+- If `isHighScore()` returns true, render a text input
+  for the player's name and an "Add Score" button.
+- After submission, display the updated scoreboard for
+  that difficulty.
+
+**Styling**: existing CSS overlay patterns, retro
+"Press Start 2P" font. No new frameworks.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `src/types.d.ts` | Add `clickedMime`, `wrongFlag`, `score`, scoreboard types |
+| `src/gameReducer.ts` | Mine reveal on loss, score init/decrement |
+| `src/Square.tsx` | Render revealed mines, wrong flags |
+| `src/utils/score.ts` | New — `getBaseScore` utility |
+| `src/hooks/useScoreboard.ts` | New — localStorage scoreboard hook |
+| `src/Scoreboard.tsx` | New — scoreboard overlay component |
+| `src/App.tsx` | Wire score display, scoreboard button, win overlay changes |
+| `src/App.css` | Scoreboard styles, wrong-flag styles |
+| `src/images/` | Possible X overlay image for wrong flags |
+
+## Testing
+
+- Reducer tests: mine reveal on loss, wrong flag marking,
+  score computation, tick decrement
+- Score utility: base score per difficulty, floor at 0
+- Scoreboard hook: add/read/sort/trim, localStorage
+  read/write, default population
+- Component tests: overlay rendering, score display,
+  name input behavior

--- a/docs/plans/2026-03-01-game-over-score-scoreboard-plan.md
+++ b/docs/plans/2026-03-01-game-over-score-scoreboard-plan.md
@@ -1,0 +1,1414 @@
+# Game Over Reveal, Score, and Scoreboard Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add mine-reveal on game-over loss, a time-based scoring system, and a persistent top-10 scoreboard per difficulty.
+
+**Architecture:** All game state changes flow through `gameReducer.ts`. New fields (`clickedMime`, `wrongFlag`, `score`) are added to existing types and the reducer handles their transitions. The scoreboard lives in a custom hook backed by localStorage. New UI components are DOM overlays matching the existing pattern in `App.tsx`.
+
+**Tech Stack:** React 19, TypeScript 5.8, Vitest 4, Konva (for Square rendering), localStorage (for scoreboard persistence).
+
+---
+
+## Task 1: Add `clickedMime` and `wrongFlag` to GameSquare
+
+**Files:**
+
+- Modify: `src/types.d.ts:4-17`
+- Modify: `src/utils/testHelpers.ts:5-16`
+
+**Step 1: Update GameSquare interface**
+
+In `src/types.d.ts`, add two optional boolean fields to `GameSquare`:
+
+```typescript
+export interface GameSquare {
+  mime: boolean;
+  adjacentMimes: 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8;
+  opened: boolean;
+  flagged: boolean;
+  x: number;
+  y: number;
+  clickedMime?: boolean;
+  wrongFlag?: boolean;
+}
+```
+
+**Step 2: Update `createTestSquare` defaults**
+
+In `src/utils/testHelpers.ts`, the spread pattern already handles optional fields (they default to `undefined` which is falsy). No change needed here — just verify existing tests still pass.
+
+**Step 3: Run tests to verify nothing breaks**
+
+Run: `pnpm test`
+Expected: All 185 tests pass. The new optional fields don't affect existing code.
+
+**Step 4: Commit**
+
+```text
+Adhoc: Added: clickedMime and wrongFlag optional fields to GameSquare
+```
+
+---
+
+## Task 2: Add `score` to GameState and reducer
+
+**Files:**
+
+- Modify: `src/gameReducer.ts:13-22` (GameState interface)
+- Modify: `src/gameReducer.ts:33-42` (initialState)
+- Create: `src/utils/score.ts`
+- Create: `src/utils/score.spec.ts`
+- Modify: `src/gameReducer.ts:56-65` (START_GAME case)
+- Modify: `src/gameReducer.ts:77-78` (TICK case)
+- Modify: `src/gameReducer.spec.ts`
+
+**Step 1: Create `src/utils/score.ts` with `getBaseScore`**
+
+```typescript
+import { GridSize } from "../enums.ts";
+
+const BASE_SCORE = 1000;
+const MULTIPLIER = 5;
+const DECREMENT_PER_SECOND = 5;
+
+const difficultyMultiplier: Record<GridSize, number> = {
+  [GridSize.XS]: 0,
+  [GridSize.S]: 0,
+  [GridSize.M]: 1,
+  [GridSize.L]: 2,
+  [GridSize.XL]: 3,
+};
+
+export function getBaseScore(gridSize: GridSize): number {
+  const mult = difficultyMultiplier[gridSize] ?? 0;
+  return BASE_SCORE + BASE_SCORE * MULTIPLIER * mult;
+}
+
+export function decrementScore(currentScore: number): number {
+  return Math.max(0, currentScore - DECREMENT_PER_SECOND);
+}
+```
+
+**Step 2: Write tests for score utilities**
+
+Create `src/utils/score.spec.ts`:
+
+```typescript
+import { GridSize } from "../enums.ts";
+import { decrementScore, getBaseScore } from "./score.ts";
+
+describe("getBaseScore", () => {
+  test("returns 1000 for GridSize.XS", () => {
+    expect(getBaseScore(GridSize.XS)).toBe(1000);
+  });
+
+  test("returns 1000 for GridSize.S (small)", () => {
+    expect(getBaseScore(GridSize.S)).toBe(1000);
+  });
+
+  test("returns 6000 for GridSize.M (medium)", () => {
+    expect(getBaseScore(GridSize.M)).toBe(6000);
+  });
+
+  test("returns 11000 for GridSize.L (large)", () => {
+    expect(getBaseScore(GridSize.L)).toBe(11000);
+  });
+
+  test("returns 16000 for GridSize.XL", () => {
+    expect(getBaseScore(GridSize.XL)).toBe(16000);
+  });
+});
+
+describe("decrementScore", () => {
+  test("decrements by 5", () => {
+    expect(decrementScore(1000)).toBe(995);
+  });
+
+  test("floors at 0", () => {
+    expect(decrementScore(3)).toBe(0);
+  });
+
+  test("returns 0 when already 0", () => {
+    expect(decrementScore(0)).toBe(0);
+  });
+});
+```
+
+**Step 3: Run score tests to verify they pass**
+
+Run: `pnpm test`
+Expected: New score tests pass, all existing tests pass.
+
+**Step 4: Add `score` to `GameState` and `initialState`**
+
+In `src/gameReducer.ts`, add `score: number` to `GameState`:
+
+```typescript
+export interface GameState {
+  game: Map<Coordinate, GameSquare> | null;
+  boardSize: GridSize;
+  status: GameStatus;
+  numMimes: MimeSize;
+  numFlags: number;
+  numOpenSpaces: number;
+  playTime: number;
+  showRules: boolean;
+  score: number;
+}
+```
+
+Update `initialState`:
+
+```typescript
+export const initialState: GameState = {
+  game: null,
+  boardSize: GridSize.S,
+  status: "waitingStart",
+  numMimes: MimeSize.S,
+  numFlags: MimeSize.S,
+  numOpenSpaces: 0,
+  playTime: 0,
+  showRules: false,
+  score: 0,
+};
+```
+
+**Step 5: Update `START_GAME` to compute initial score**
+
+Import `getBaseScore` at the top of `gameReducer.ts`:
+
+```typescript
+import { getBaseScore } from "./utils/score.ts";
+```
+
+Update the `START_GAME` case to set `score`:
+
+```typescript
+case "START_GAME":
+  return {
+    ...state,
+    status: "waitingStart",
+    boardSize: action.boardSize,
+    numMimes: action.numMimes,
+    numFlags: action.numMimes,
+    numOpenSpaces: 0,
+    playTime: 0,
+    score: getBaseScore(action.boardSize),
+  };
+```
+
+**Step 6: Update `TICK` to decrement score**
+
+Import `decrementScore` at the top of `gameReducer.ts`:
+
+```typescript
+import { decrementScore, getBaseScore } from "./utils/score.ts";
+```
+
+Update the `TICK` case:
+
+```typescript
+case "TICK":
+  return {
+    ...state,
+    playTime: state.playTime + 1,
+    score: decrementScore(state.score),
+  };
+```
+
+**Step 7: Add reducer tests for score**
+
+In `src/gameReducer.spec.ts`, add these tests:
+
+In the `initialState` describe block, add:
+
+```typescript
+test("has score initialized to 0", () => {
+  expect(initialState.score).toBe(0);
+});
+```
+
+In the `START_GAME` describe block, add:
+
+```typescript
+test("sets score based on board size for Small", () => {
+  const result = gameReducer(initialState, {
+    type: "START_GAME",
+    boardSize: GridSize.S,
+    numMimes: MimeSize.S,
+  });
+  expect(result.score).toBe(1000);
+});
+
+test("sets score based on board size for Medium", () => {
+  const result = gameReducer(initialState, {
+    type: "START_GAME",
+    boardSize: GridSize.M,
+    numMimes: MimeSize.M,
+  });
+  expect(result.score).toBe(6000);
+});
+
+test("sets score based on board size for Large", () => {
+  const result = gameReducer(initialState, {
+    type: "START_GAME",
+    boardSize: GridSize.L,
+    numMimes: MimeSize.L,
+  });
+  expect(result.score).toBe(11000);
+});
+
+test("sets score based on board size for XL", () => {
+  const result = gameReducer(initialState, {
+    type: "START_GAME",
+    boardSize: GridSize.XL,
+    numMimes: MimeSize.XL,
+  });
+  expect(result.score).toBe(16000);
+});
+```
+
+In the `TICK` describe block, add:
+
+```typescript
+test("decrements score by 5", () => {
+  const state: GameState = { ...initialState, score: 1000 };
+  const result = gameReducer(state, { type: "TICK" });
+  expect(result.score).toBe(995);
+});
+
+test("score does not go below 0", () => {
+  const state: GameState = { ...initialState, score: 2 };
+  const result = gameReducer(state, { type: "TICK" });
+  expect(result.score).toBe(0);
+});
+```
+
+**Step 8: Run all tests**
+
+Run: `pnpm test`
+Expected: All tests pass including new score-related tests.
+
+**Step 9: Commit**
+
+```text
+Adhoc: Added: Score system with base score per difficulty and time decrement
+```
+
+---
+
+## Task 3: Reveal mines on game-over loss in reducer
+
+**Files:**
+
+- Modify: `src/gameReducer.ts:116-135` (SQUARE_CLICK case, loss path)
+- Modify: `src/gameReducer.ts:158-191` (SQUARE_DOUBLE_CLICK case, loss path)
+- Modify: `src/gameReducer.spec.ts`
+
+**Step 1: Write failing tests for mine reveal on loss**
+
+Add these tests to `src/gameReducer.spec.ts` inside a new `describe("mine reveal on game over")` block within the `SQUARE_CLICK` describe:
+
+```typescript
+describe("mine reveal on game over", () => {
+  test("reveals all unflagged mines when game is lost", () => {
+    const board = createTestBoard(3);
+    // Place mines at 1|0 and 2|0 (not at 0|0 which we click)
+    const mine1 = board.get("1|0" as Coordinate)!;
+    mine1.mime = true;
+    const mine2 = board.get("2|0" as Coordinate)!;
+    mine2.mime = true;
+
+    const state: GameState = {
+      ...initialState,
+      game: board,
+      status: "inProgress",
+      numMimes: MimeSize.XS,
+    };
+
+    // Click the mine at 1|0 to trigger loss
+    vi.spyOn(gameLogic, "processSquareClick").mockReturnValue({
+      openedCount: 0,
+      lost: true,
+    });
+
+    const result = gameReducer(state, {
+      type: "SQUARE_CLICK",
+      coordinate: "1|0" as Coordinate,
+    });
+
+    // The other mine should be revealed
+    const otherMine = result.game?.get("2|0" as Coordinate);
+    expect(otherMine?.opened).toBe(true);
+  });
+
+  test("marks clicked mine with clickedMime flag", () => {
+    const board = createTestBoard(3);
+    const mine = board.get("1|0" as Coordinate)!;
+    mine.mime = true;
+
+    const state: GameState = {
+      ...initialState,
+      game: board,
+      status: "inProgress",
+      numMimes: MimeSize.XS,
+    };
+
+    vi.spyOn(gameLogic, "processSquareClick").mockReturnValue({
+      openedCount: 0,
+      lost: true,
+    });
+
+    const result = gameReducer(state, {
+      type: "SQUARE_CLICK",
+      coordinate: "1|0" as Coordinate,
+    });
+
+    const clickedMine = result.game?.get("1|0" as Coordinate);
+    expect(clickedMine?.clickedMime).toBe(true);
+  });
+
+  test("marks wrongly flagged non-mine squares", () => {
+    const board = createTestBoard(3);
+    const mine = board.get("1|0" as Coordinate)!;
+    mine.mime = true;
+    // Flag a non-mine square (wrong flag)
+    const wrongSquare = board.get("0|1" as Coordinate)!;
+    wrongSquare.flagged = true;
+
+    const state: GameState = {
+      ...initialState,
+      game: board,
+      status: "inProgress",
+      numMimes: MimeSize.XS,
+    };
+
+    vi.spyOn(gameLogic, "processSquareClick").mockReturnValue({
+      openedCount: 0,
+      lost: true,
+    });
+
+    const result = gameReducer(state, {
+      type: "SQUARE_CLICK",
+      coordinate: "1|0" as Coordinate,
+    });
+
+    const wrong = result.game?.get("0|1" as Coordinate);
+    expect(wrong?.wrongFlag).toBe(true);
+  });
+
+  test("does not mark correctly flagged mines as wrongFlag", () => {
+    const board = createTestBoard(3);
+    const mine1 = board.get("1|0" as Coordinate)!;
+    mine1.mime = true;
+    // Correctly flag another mine
+    const mine2 = board.get("2|0" as Coordinate)!;
+    mine2.mime = true;
+    mine2.flagged = true;
+
+    const state: GameState = {
+      ...initialState,
+      game: board,
+      status: "inProgress",
+      numMimes: MimeSize.XS,
+    };
+
+    vi.spyOn(gameLogic, "processSquareClick").mockReturnValue({
+      openedCount: 0,
+      lost: true,
+    });
+
+    const result = gameReducer(state, {
+      type: "SQUARE_CLICK",
+      coordinate: "1|0" as Coordinate,
+    });
+
+    const correctFlag = result.game?.get("2|0" as Coordinate);
+    expect(correctFlag?.wrongFlag).toBeUndefined();
+  });
+});
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `pnpm test`
+Expected: New mine-reveal tests fail (mines not yet revealed on loss).
+
+**Step 3: Implement mine reveal logic in reducer**
+
+Create a helper function `revealMinesOnLoss` in `src/gameReducer.ts`, placed above `gameReducer`:
+
+```typescript
+function revealMinesOnLoss(
+  game: Map<Coordinate, GameSquare>,
+  clickedCoord: Coordinate,
+): void {
+  for (const [coord, square] of game) {
+    if (coord === clickedCoord) {
+      square.clickedMime = true;
+    } else if (square.mime && !square.flagged) {
+      square.opened = true;
+    } else if (!square.mime && square.flagged) {
+      square.wrongFlag = true;
+    }
+  }
+}
+```
+
+In the `SQUARE_CLICK` case, after `if (result.lost)`, add the mine reveal call:
+
+```typescript
+if (result.lost) {
+  nextStatus = "gameOverLost";
+  revealMinesOnLoss(nextGame, action.coordinate);
+}
+```
+
+In the `SQUARE_DOUBLE_CLICK` case, add the same pattern. The double-click loss path does not have a single "clicked" mine coordinate — all unflagged adjacent mines were force-opened. Use the action coordinate as clickedCoord (the square the player double-clicked, even if it is not itself a mine):
+
+```typescript
+if (result.lost) {
+  nextStatus = "gameOverLost";
+  revealMinesOnLoss(nextGame, action.coordinate);
+}
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `pnpm test`
+Expected: All tests pass including mine-reveal tests.
+
+**Step 5: Commit**
+
+```text
+Adhoc: Added: Reveal all mines and mark wrong flags on game-over loss
+```
+
+---
+
+## Task 4: Update Square.tsx rendering for revealed mines and wrong flags
+
+**Files:**
+
+- Modify: `src/Square.tsx`
+- Modify: `src/Square.spec.tsx`
+
+**Step 1: Write failing tests for new Square visual states**
+
+Add these tests to `src/Square.spec.tsx`. First, update the `renderSquare` defaultProps to include the new optional fields (they default to `undefined`/falsy, so no changes needed to the type since `GameSquare` already includes them as optional after Task 1).
+
+In the `rendering states` describe block, add:
+
+```typescript
+test("renders revealed mine (not clicked) with white fill and mime image", () => {
+  renderSquare({
+    opened: true,
+    mime: true,
+    isGameOver: true,
+    clickedMime: false,
+  });
+  const rect = screen.getByTestId("konva-rect");
+  expect(rect.dataset.fill).toBe("#FFFFFF");
+  const images = screen.getAllByTestId("konva-image");
+  expect(images.length).toBeGreaterThanOrEqual(1);
+});
+
+test("renders clicked mine with red fill", () => {
+  renderSquare({
+    opened: true,
+    mime: true,
+    isGameOver: true,
+    clickedMime: true,
+  });
+  const rect = screen.getByTestId("konva-rect");
+  expect(rect.dataset.fill).toBe("#f80000");
+});
+
+test("renders wrong flag with X text", () => {
+  renderSquare({
+    flagged: true,
+    wrongFlag: true,
+    isGameOver: true,
+  });
+  expect(screen.getByText("X")).toBeInTheDocument();
+});
+```
+
+In the `color states` describe block, update the existing "opened mine has red fill" test to also pass `clickedMime: true` so it still expects red:
+
+```typescript
+test("opened mine has red fill when clickedMime", () => {
+  renderSquare({ opened: true, mime: true, clickedMime: true });
+  const rect = screen.getByTestId("konva-rect");
+  expect(rect.dataset.fill).toBe("#f80000");
+});
+```
+
+**Step 2: Run tests to verify new tests fail**
+
+Run: `pnpm test`
+Expected: New rendering tests fail (Square doesn't yet distinguish clicked vs revealed mines).
+
+**Step 3: Update Square.tsx rendering**
+
+Update the `SquareProps` interface to include the new fields (they come through `GameSquare` but we need to destructure them). Add `clickedMime` and `wrongFlag` to the destructured props:
+
+```typescript
+function Square({
+  coOrd,
+  x,
+  y,
+  size,
+  onSelect,
+  onRightClick,
+  onDoubleClick,
+  mime,
+  opened,
+  flagged,
+  isGameOver,
+  adjacentMimes,
+  clickedMime,
+  wrongFlag,
+}: SquareProps & GameSquare) {
+```
+
+Update the `color` useMemo to distinguish clicked vs revealed mines:
+
+```typescript
+const color = useMemo(() => {
+  if (opened && mime && clickedMime) {
+    return mimeColor;
+  }
+  if (opened && mime) {
+    return unopenedColor;
+  }
+  if (opened) {
+    return gradientArray[adjacentMimes];
+  }
+  return unopenedColor;
+}, [opened, mime, adjacentMimes, clickedMime]);
+```
+
+Update the rendering JSX. The mine image should show for any opened mine during game over. For wrong flags, show an "X" text overlay on top of the flag:
+
+```tsx
+{flagged && flagImg && (
+  <Image image={flagImg} height={size} width={size} x={x} y={y} />
+)}
+{wrongFlag && isGameOver ? (
+  <Text
+    x={x}
+    y={y}
+    width={size}
+    height={size}
+    padding={textPadding}
+    align="center"
+    text="X"
+    fontFamily="Press Start 2P"
+    fill="#f80000"
+    fontSize={14}
+  />
+) : opened && mime && isGameOver ? (
+  <Image image={gameOverMime} height={size} width={size} x={x} y={y} />
+) : (
+  <Text
+    x={x}
+    y={y}
+    width={size}
+    height={size}
+    padding={textPadding}
+    align="center"
+    text={opened ? String(adjacentMimes) : ``}
+    fontFamily="Press Start 2P"
+  />
+)}
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `pnpm test`
+Expected: All tests pass. The existing "opened mine has red fill" test in color states may need updating — it currently tests `opened: true, mime: true` without `clickedMime`. After the change, an opened mine without `clickedMime` renders white. Update that test to reflect the new behavior (revealed mine = white) or add `clickedMime: true` to preserve the red assertion.
+
+**Step 5: Commit**
+
+```text
+Adhoc: Added: Square rendering for revealed mines, clicked mines, and wrong flags
+```
+
+---
+
+## Task 5: Display score in game header and win overlay
+
+**Files:**
+
+- Modify: `src/App.tsx:60` (destructure score from state)
+- Modify: `src/App.tsx:133-150` (game-over overlay)
+- Modify: `src/App.tsx:162-166` (header display)
+
+**Step 1: Add score to the header display**
+
+In `src/App.tsx`, destructure `score` from state:
+
+```typescript
+const { game, boardSize, status, numFlags, playTime, showRules, score } = state;
+```
+
+Update the header `<h4>` to include the score:
+
+```tsx
+<h4>
+  <small>
+    Play time: {playTime}s | Score: {score} | Flags Remaining:{" "}
+    {numFlags < 0 ? "No more left!" : numFlags}
+  </small>
+</h4>
+```
+
+**Step 2: Show final score prominently in win overlay**
+
+Update the game-over overlay. When the player wins, show the score in large text:
+
+```tsx
+{isGameOver ? (
+  <div className="overlay">
+    <div className="content">
+      <h4>
+        GAME OVER! You {status === "gameOverLost" ? "Lost :(" : "Won! :)"}
+      </h4>
+      {status === "gameOverWon" && (
+        <h2 className="final-score">Score: {score}</h2>
+      )}
+      <img
+        alt="Game Over!"
+        src={gameOverImage}
+        style={{ width: "8rem" }}
+      />
+      <p>New Game?</p>
+      <div className="buttons">
+        <DifficultyButtons onRestart={handleRestart} />
+      </div>
+    </div>
+  </div>
+) : null}
+```
+
+**Step 3: Add CSS for final-score**
+
+In `src/App.css`, add after the `.container .overlay .content .buttons` rule:
+
+```css
+.container .overlay .content .final-score {
+  color: #1bbb00;
+  margin: 1rem 0;
+}
+```
+
+**Step 4: Run tests**
+
+Run: `pnpm test`
+Expected: All tests pass.
+
+**Step 5: Commit**
+
+```text
+Adhoc: Added: Score display in game header and win overlay
+```
+
+---
+
+## Task 6: Create `useScoreboard` hook
+
+**Files:**
+
+- Create: `src/hooks/useScoreboard.ts`
+- Create: `src/hooks/useScoreboard.spec.ts`
+
+**Step 1: Define scoreboard types**
+
+Add to `src/types.d.ts`:
+
+```typescript
+export interface ScoreEntry {
+  name: string;
+  score: number;
+}
+
+export type DifficultyKey = "S" | "M" | "L" | "XL";
+
+export type ScoreboardData = Record<DifficultyKey, ScoreEntry[]>;
+```
+
+**Step 2: Create the hook**
+
+Create `src/hooks/useScoreboard.ts`:
+
+```typescript
+import { useCallback, useState } from "react";
+import type { DifficultyKey, ScoreEntry, ScoreboardData } from "types.d";
+
+const STORAGE_KEY = "mimesweeper-scoreboard";
+const MAX_ENTRIES = 10;
+
+const DEFAULT_ENTRY: ScoreEntry = { name: "JMS", score: 100 };
+
+function createDefaultScoreboard(): ScoreboardData {
+  const entries = Array.from({ length: MAX_ENTRIES }, () => ({
+    ...DEFAULT_ENTRY,
+  }));
+  return {
+    S: entries.map((e) => ({ ...e })),
+    M: entries.map((e) => ({ ...e })),
+    L: entries.map((e) => ({ ...e })),
+    XL: entries.map((e) => ({ ...e })),
+  };
+}
+
+function loadScoreboard(): ScoreboardData {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored) {
+      return JSON.parse(stored) as ScoreboardData;
+    }
+  } catch {
+    // Corrupted data — fall back to defaults
+  }
+  const defaults = createDefaultScoreboard();
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(defaults));
+  return defaults;
+}
+
+function saveScoreboard(data: ScoreboardData): void {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+}
+
+export function useScoreboard() {
+  const [scores, setScores] = useState<ScoreboardData>(loadScoreboard);
+
+  const getScores = useCallback(
+    (difficulty: DifficultyKey): ScoreEntry[] => {
+      return scores[difficulty];
+    },
+    [scores],
+  );
+
+  const isHighScore = useCallback(
+    (difficulty: DifficultyKey, score: number): boolean => {
+      const entries = scores[difficulty];
+      if (entries.length < MAX_ENTRIES) return true;
+      return score > entries[entries.length - 1].score;
+    },
+    [scores],
+  );
+
+  const addScore = useCallback(
+    (difficulty: DifficultyKey, name: string, score: number): void => {
+      setScores((prev) => {
+        const entries = [...prev[difficulty], { name, score }];
+        entries.sort((a, b) => b.score - a.score);
+        const trimmed = entries.slice(0, MAX_ENTRIES);
+        const next = { ...prev, [difficulty]: trimmed };
+        saveScoreboard(next);
+        return next;
+      });
+    },
+    [],
+  );
+
+  return { scores, getScores, isHighScore, addScore };
+}
+```
+
+**Step 3: Write tests for useScoreboard**
+
+Create `src/hooks/useScoreboard.spec.ts`:
+
+```typescript
+import { act, renderHook } from "@testing-library/react";
+import { useScoreboard } from "./useScoreboard.ts";
+
+describe("useScoreboard", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  test("initializes with default scoreboard entries", () => {
+    const { result } = renderHook(() => useScoreboard());
+    const smallScores = result.current.getScores("S");
+    expect(smallScores).toHaveLength(10);
+    expect(smallScores[0]).toEqual({ name: "JMS", score: 100 });
+  });
+
+  test("each difficulty has its own default entries", () => {
+    const { result } = renderHook(() => useScoreboard());
+    for (const key of ["S", "M", "L", "XL"] as const) {
+      expect(result.current.getScores(key)).toHaveLength(10);
+    }
+  });
+
+  test("persists defaults to localStorage on first load", () => {
+    renderHook(() => useScoreboard());
+    const stored = localStorage.getItem("mimesweeper-scoreboard");
+    expect(stored).not.toBeNull();
+    const parsed = JSON.parse(stored!);
+    expect(parsed.S).toHaveLength(10);
+  });
+
+  test("isHighScore returns true when score beats lowest entry", () => {
+    const { result } = renderHook(() => useScoreboard());
+    expect(result.current.isHighScore("S", 200)).toBe(true);
+  });
+
+  test("isHighScore returns false when score is at or below lowest", () => {
+    const { result } = renderHook(() => useScoreboard());
+    expect(result.current.isHighScore("S", 50)).toBe(false);
+  });
+
+  test("isHighScore returns false when score equals lowest", () => {
+    const { result } = renderHook(() => useScoreboard());
+    expect(result.current.isHighScore("S", 100)).toBe(false);
+  });
+
+  test("addScore inserts entry in sorted order", () => {
+    const { result } = renderHook(() => useScoreboard());
+    act(() => {
+      result.current.addScore("S", "ACE", 500);
+    });
+    const scores = result.current.getScores("S");
+    expect(scores[0]).toEqual({ name: "ACE", score: 500 });
+    expect(scores).toHaveLength(10);
+  });
+
+  test("addScore persists to localStorage", () => {
+    const { result } = renderHook(() => useScoreboard());
+    act(() => {
+      result.current.addScore("M", "PRO", 9999);
+    });
+    const stored = JSON.parse(
+      localStorage.getItem("mimesweeper-scoreboard")!,
+    );
+    expect(stored.M[0]).toEqual({ name: "PRO", score: 9999 });
+  });
+
+  test("addScore trims list to 10 entries", () => {
+    const { result } = renderHook(() => useScoreboard());
+    act(() => {
+      result.current.addScore("S", "NEW", 500);
+    });
+    expect(result.current.getScores("S")).toHaveLength(10);
+  });
+
+  test("loads existing scores from localStorage", () => {
+    const custom = {
+      S: [{ name: "TOP", score: 9999 }],
+      M: [],
+      L: [],
+      XL: [],
+    };
+    localStorage.setItem(
+      "mimesweeper-scoreboard",
+      JSON.stringify(custom),
+    );
+    const { result } = renderHook(() => useScoreboard());
+    expect(result.current.getScores("S")[0]).toEqual({
+      name: "TOP",
+      score: 9999,
+    });
+  });
+
+  test("falls back to defaults on corrupted localStorage", () => {
+    localStorage.setItem("mimesweeper-scoreboard", "not-json{{{");
+    const { result } = renderHook(() => useScoreboard());
+    expect(result.current.getScores("S")).toHaveLength(10);
+  });
+});
+```
+
+**Step 4: Run tests**
+
+Run: `pnpm test`
+Expected: All scoreboard tests pass.
+
+**Step 5: Commit**
+
+```text
+Adhoc: Added: useScoreboard hook with localStorage persistence and defaults
+```
+
+---
+
+## Task 7: Create Scoreboard component
+
+**Files:**
+
+- Create: `src/Scoreboard.tsx`
+- Create: `src/Scoreboard.spec.tsx`
+- Modify: `src/App.css`
+
+**Step 1: Create `src/Scoreboard.tsx`**
+
+```tsx
+import { useCallback, useState } from "react";
+import type { DifficultyKey, ScoreEntry } from "types.d";
+
+const DIFFICULTY_LABELS: Record<DifficultyKey, string> = {
+  S: "Small",
+  M: "Medium",
+  L: "Large",
+  XL: "XL",
+};
+
+const DIFFICULTY_KEYS: DifficultyKey[] = ["S", "M", "L", "XL"];
+
+interface ScoreboardProps {
+  getScores: (difficulty: DifficultyKey) => ScoreEntry[];
+  onClose: () => void;
+}
+
+function Scoreboard({ getScores, onClose }: ScoreboardProps) {
+  const [activeDifficulty, setActiveDifficulty] =
+    useState<DifficultyKey>("S");
+
+  const entries = getScores(activeDifficulty);
+
+  const handleTabClick = useCallback((key: DifficultyKey) => {
+    setActiveDifficulty(key);
+  }, []);
+
+  return (
+    <div className="overlay">
+      <div className="content scoreboard">
+        <h4>Top 10 Scores</h4>
+        <div className="scoreboard-tabs">
+          {DIFFICULTY_KEYS.map((key) => (
+            <button
+              key={key}
+              type="button"
+              className={activeDifficulty === key ? "active" : ""}
+              onClick={() => handleTabClick(key)}
+            >
+              {DIFFICULTY_LABELS[key]}
+            </button>
+          ))}
+        </div>
+        <ol className="scoreboard-list">
+          {entries.map((entry, index) => (
+            <li key={`${String(index)}-${entry.name}`}>
+              <span className="scoreboard-name">{entry.name}</span>
+              <span className="scoreboard-score">{entry.score}</span>
+            </li>
+          ))}
+        </ol>
+        <div className="buttons">
+          <button type="button" onClick={onClose}>
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default Scoreboard;
+```
+
+**Step 2: Add scoreboard CSS**
+
+In `src/App.css`, add at the end:
+
+```css
+.container .overlay .content.scoreboard {
+  width: 35rem;
+}
+
+.container .scoreboard-tabs {
+  display: flex;
+  justify-content: center;
+  gap: 0.5rem;
+  margin: 1rem 0;
+}
+
+.container .scoreboard-tabs button.active {
+  background-color: color-mix(
+    in srgb,
+    var(--button-bg-color) 60%,
+    var(--white)
+  );
+}
+
+.container .scoreboard-list {
+  text-align: left;
+  list-style: none;
+  padding: 0;
+  margin: 1rem auto;
+  max-width: 25rem;
+}
+
+.container .scoreboard-list li {
+  display: flex;
+  justify-content: space-between;
+  padding: 0.5rem 0;
+  border-bottom: 1px solid var(--black);
+  font-size: 0.8rem;
+}
+
+.container .scoreboard-name {
+  flex: 1;
+}
+
+.container .scoreboard-score {
+  text-align: right;
+  min-width: 5rem;
+}
+```
+
+**Step 3: Write tests for Scoreboard component**
+
+Create `src/Scoreboard.spec.tsx`:
+
+```tsx
+import { fireEvent, render, screen } from "@testing-library/react";
+import Scoreboard from "./Scoreboard";
+import type { DifficultyKey, ScoreEntry } from "types.d";
+
+function createMockScores(): Record<DifficultyKey, ScoreEntry[]> {
+  return {
+    S: [
+      { name: "AAA", score: 900 },
+      { name: "BBB", score: 800 },
+    ],
+    M: [{ name: "CCC", score: 5000 }],
+    L: [],
+    XL: [{ name: "DDD", score: 15000 }],
+  };
+}
+
+describe("Scoreboard", () => {
+  test("renders heading", () => {
+    const scores = createMockScores();
+    render(
+      <Scoreboard
+        getScores={(d) => scores[d]}
+        onClose={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("Top 10 Scores")).toBeInTheDocument();
+  });
+
+  test("shows Small scores by default", () => {
+    const scores = createMockScores();
+    render(
+      <Scoreboard
+        getScores={(d) => scores[d]}
+        onClose={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("AAA")).toBeInTheDocument();
+    expect(screen.getByText("900")).toBeInTheDocument();
+  });
+
+  test("switches to Medium scores on tab click", () => {
+    const scores = createMockScores();
+    render(
+      <Scoreboard
+        getScores={(d) => scores[d]}
+        onClose={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByText("Medium"));
+    expect(screen.getByText("CCC")).toBeInTheDocument();
+    expect(screen.getByText("5000")).toBeInTheDocument();
+  });
+
+  test("calls onClose when Close button is clicked", () => {
+    const scores = createMockScores();
+    const onClose = vi.fn();
+    render(
+      <Scoreboard getScores={(d) => scores[d]} onClose={onClose} />,
+    );
+    fireEvent.click(screen.getByText("Close"));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  test("renders all four difficulty tabs", () => {
+    const scores = createMockScores();
+    render(
+      <Scoreboard
+        getScores={(d) => scores[d]}
+        onClose={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("Small")).toBeInTheDocument();
+    expect(screen.getByText("Medium")).toBeInTheDocument();
+    expect(screen.getByText("Large")).toBeInTheDocument();
+    expect(screen.getByText("XL")).toBeInTheDocument();
+  });
+});
+```
+
+**Step 4: Run tests**
+
+Run: `pnpm test`
+Expected: All tests pass.
+
+**Step 5: Commit**
+
+```text
+Adhoc: Added: Scoreboard component with difficulty tabs and score list
+```
+
+---
+
+## Task 8: Wire scoreboard and high-score entry into App.tsx
+
+**Files:**
+
+- Modify: `src/App.tsx`
+- Modify: `src/App.css`
+
+**Step 1: Add a difficulty key mapping utility**
+
+Add a helper at the top of `src/App.tsx` (or in a utility file) to map `GridSize` to `DifficultyKey`:
+
+```typescript
+import type { DifficultyKey } from "types.d";
+
+function getDifficultyKey(boardSize: GridSize): DifficultyKey {
+  switch (boardSize) {
+    case GridSize.M:
+      return "M";
+    case GridSize.L:
+      return "L";
+    case GridSize.XL:
+      return "XL";
+    default:
+      return "S";
+  }
+}
+```
+
+**Step 2: Wire useScoreboard into App**
+
+In the `App` function, add:
+
+```typescript
+const { getScores, isHighScore, addScore } = useScoreboard();
+const [showScoreboard, setShowScoreboard] = useState(false);
+const [playerName, setPlayerName] = useState("");
+const [scoreSubmitted, setScoreSubmitted] = useState(false);
+
+const difficultyKey = getDifficultyKey(boardSize);
+const qualifiesForHighScore =
+  status === "gameOverWon" && !scoreSubmitted && isHighScore(difficultyKey, score);
+```
+
+Import `useScoreboard` and `useState`:
+
+```typescript
+import { useScoreboard } from "./hooks/useScoreboard.ts";
+```
+
+**Step 3: Add Scoreboard button to game header**
+
+After the "How to play" button, add a Scoreboard button:
+
+```tsx
+<h4>
+  Mimesweeper{" "}
+  <button
+    type="button"
+    onClick={() => {
+      dispatch({ type: "TOGGLE_RULES" });
+    }}
+  >
+    How to play
+  </button>{" "}
+  <button
+    type="button"
+    onClick={() => {
+      setShowScoreboard(true);
+    }}
+  >
+    Scoreboard
+  </button>
+</h4>
+```
+
+**Step 4: Render Scoreboard overlay when showScoreboard is true**
+
+Add before the game-over overlay conditional:
+
+```tsx
+{showScoreboard ? (
+  <Scoreboard
+    getScores={getScores}
+    onClose={() => setShowScoreboard(false)}
+  />
+) : null}
+```
+
+Import Scoreboard:
+
+```typescript
+import Scoreboard from "./Scoreboard";
+```
+
+**Step 5: Add high-score entry to win overlay**
+
+Update the game-over overlay to include score submission:
+
+```tsx
+{isGameOver ? (
+  <div className="overlay">
+    <div className="content">
+      <h4>
+        GAME OVER! You {status === "gameOverLost" ? "Lost :(" : "Won! :)"}
+      </h4>
+      {status === "gameOverWon" && (
+        <>
+          <h2 className="final-score">Score: {score}</h2>
+          {qualifiesForHighScore ? (
+            <div className="high-score-entry">
+              <p>New High Score!</p>
+              <input
+                type="text"
+                maxLength={10}
+                placeholder="Your name"
+                value={playerName}
+                onChange={(e) => setPlayerName(e.target.value)}
+              />
+              <button
+                type="button"
+                disabled={playerName.trim().length === 0}
+                onClick={() => {
+                  addScore(difficultyKey, playerName.trim(), score);
+                  setScoreSubmitted(true);
+                }}
+              >
+                Submit Score
+              </button>
+            </div>
+          ) : scoreSubmitted ? (
+            <p>Score saved!</p>
+          ) : null}
+        </>
+      )}
+      <img
+        alt="Game Over!"
+        src={gameOverImage}
+        style={{ width: "8rem" }}
+      />
+      <p>New Game?</p>
+      <div className="buttons">
+        <DifficultyButtons onRestart={handleRestart} />
+      </div>
+    </div>
+  </div>
+) : null}
+```
+
+**Step 6: Reset score submission state on restart**
+
+Update `handleRestart` to clear the submission state:
+
+```typescript
+const handleRestart = useCallback(
+  (mimes: MimeSize = MimeSize.S, size: GridSize = GridSize.S): void => {
+    dispatch({ type: "START_GAME", boardSize: size, numMimes: mimes });
+    setPlayerName("");
+    setScoreSubmitted(false);
+  },
+  [],
+);
+```
+
+**Step 7: Add CSS for high-score entry**
+
+In `src/App.css`:
+
+```css
+.container .overlay .content .high-score-entry {
+  margin: 1rem 0;
+}
+
+.container .overlay .content .high-score-entry input {
+  font-family: "Press Start 2P", cursive;
+  font-size: 0.8rem;
+  padding: 0.5rem;
+  border: 2px solid var(--black);
+  margin-right: 0.5rem;
+  max-width: 10rem;
+}
+```
+
+**Step 8: Run all tests**
+
+Run: `pnpm test`
+Expected: All tests pass.
+
+**Step 9: Run lint**
+
+Run: `pnpm run lint`
+Expected: No lint errors.
+
+**Step 10: Commit**
+
+```text
+Adhoc: Added: Scoreboard button, high-score entry on win, and full wiring in App
+```
+
+---
+
+## Task 9: Final integration test and cleanup
+
+**Files:**
+
+- Modify: `src/App.spec.tsx` (add integration tests)
+
+**Step 1: Add integration tests**
+
+Add tests to `src/App.spec.tsx` to verify:
+
+1. Score displays in header during game
+2. Score displays in win overlay
+3. Scoreboard button opens scoreboard overlay
+4. High-score entry form appears on win when qualifying
+
+These tests depend on the existing App test patterns (rendering App, clicking squares). Follow the established mock patterns in `App.spec.tsx`.
+
+**Step 2: Run full test suite**
+
+Run: `pnpm test`
+Expected: All tests pass with coverage above 80%.
+
+**Step 3: Run lint and type check**
+
+Run: `pnpm run lint && pnpm run build`
+Expected: Clean lint, successful build.
+
+**Step 4: Commit**
+
+```text
+Adhoc: Added: Integration tests for score display and scoreboard
+```
+
+---
+
+## Summary of all files touched
+
+| File | Action |
+|------|--------|
+| `src/types.d.ts` | Modify — add `clickedMime?`, `wrongFlag?`, `ScoreEntry`, `DifficultyKey`, `ScoreboardData` |
+| `src/utils/score.ts` | Create — `getBaseScore`, `decrementScore` |
+| `src/utils/score.spec.ts` | Create — score utility tests |
+| `src/gameReducer.ts` | Modify — add `score` to state, `revealMinesOnLoss`, update `START_GAME`/`TICK`/click actions |
+| `src/gameReducer.spec.ts` | Modify — add mine-reveal and score tests |
+| `src/Square.tsx` | Modify — render revealed mines (white), clicked mines (red), wrong flags (X) |
+| `src/Square.spec.tsx` | Modify — add rendering tests for new states |
+| `src/hooks/useScoreboard.ts` | Create — localStorage-backed scoreboard hook |
+| `src/hooks/useScoreboard.spec.ts` | Create — scoreboard hook tests |
+| `src/Scoreboard.tsx` | Create — scoreboard overlay component |
+| `src/Scoreboard.spec.tsx` | Create — scoreboard component tests |
+| `src/App.tsx` | Modify — wire score, scoreboard button, high-score entry |
+| `src/App.css` | Modify — add scoreboard and high-score-entry styles |
+| `src/App.spec.tsx` | Modify — add integration tests |

--- a/src/App.css
+++ b/src/App.css
@@ -93,3 +93,8 @@
 .container .overlay .content .buttons {
   margin-top: 1rem;
 }
+
+.container .overlay .content .final-score {
+  color: #1bbb00;
+  margin: 1rem 0;
+}

--- a/src/App.css
+++ b/src/App.css
@@ -142,3 +142,16 @@
   text-align: right;
   min-width: 5rem;
 }
+
+.container .overlay .content .high-score-entry {
+  margin: 1rem 0;
+}
+
+.container .overlay .content .high-score-entry input {
+  font-family: "Press Start 2P", cursive;
+  font-size: 0.8rem;
+  padding: 0.5rem;
+  border: 2px solid var(--black);
+  margin-right: 0.5rem;
+  max-width: 10rem;
+}

--- a/src/App.css
+++ b/src/App.css
@@ -98,3 +98,47 @@
   color: #1bbb00;
   margin: 1rem 0;
 }
+
+.container .overlay .content.scoreboard {
+  width: 35rem;
+}
+
+.container .scoreboard-tabs {
+  display: flex;
+  justify-content: center;
+  gap: 0.5rem;
+  margin: 1rem 0;
+}
+
+.container .scoreboard-tabs button.active {
+  background-color: color-mix(
+    in srgb,
+    var(--button-bg-color) 60%,
+    var(--white)
+  );
+}
+
+.container .scoreboard-list {
+  text-align: left;
+  list-style: none;
+  padding: 0;
+  margin: 1rem auto;
+  max-width: 25rem;
+}
+
+.container .scoreboard-list li {
+  display: flex;
+  justify-content: space-between;
+  padding: 0.5rem 0;
+  border-bottom: 1px solid var(--black);
+  font-size: 0.8rem;
+}
+
+.container .scoreboard-name {
+  flex: 1;
+}
+
+.container .scoreboard-score {
+  text-align: right;
+  min-width: 5rem;
+}

--- a/src/App.spec.tsx
+++ b/src/App.spec.tsx
@@ -400,6 +400,132 @@ describe("App", () => {
     });
   });
 
+  describe("score and scoreboard", () => {
+    beforeEach(() => {
+      localStorage.clear();
+    });
+
+    test("displays score in header", () => {
+      render(<App />);
+      expect(screen.getByText(/Score: 0/i)).toBeInTheDocument();
+    });
+
+    test("displays initial score after starting a game", () => {
+      render(<App />);
+      const medBtns = screen.getAllByText(/Medium game/i);
+      act(() => {
+        medBtns[medBtns.length - 1].click();
+      });
+      expect(screen.getByText(/Score: 6000/i)).toBeInTheDocument();
+    });
+
+    test("Scoreboard button opens scoreboard overlay", () => {
+      render(<App />);
+      act(() => {
+        screen.getByText("Scoreboard").click();
+      });
+      expect(screen.getByText("Top 10 Scores")).toBeInTheDocument();
+    });
+
+    test("Scoreboard overlay can be closed", () => {
+      render(<App />);
+      act(() => {
+        screen.getByText("Scoreboard").click();
+      });
+      act(() => {
+        screen.getByText("Close").click();
+      });
+      expect(screen.queryByText("Top 10 Scores")).not.toBeInTheDocument();
+    });
+
+    test("shows final score in win overlay", () => {
+      render(<App />);
+
+      // Start a Small game to set score to 1000
+      const smallBtns = screen.getAllByText(/Small game/i);
+      act(() => {
+        smallBtns[smallBtns.length - 1].click();
+      });
+
+      vi.spyOn(gameLogic, "populateMimes").mockImplementation(
+        (entries: [Coordinate, GameSquare][]) =>
+          new Map<Coordinate, GameSquare>(entries),
+      );
+      vi.spyOn(gameLogic, "processSquareClick").mockReturnValue({
+        openedCount: 90,
+        lost: false,
+      });
+      vi.spyOn(gameLogic, "isWin").mockReturnValue(true);
+
+      act(() => {
+        fireEvent.click(screen.getByTestId("square-0|0"));
+      });
+
+      const scoreElements = screen.getAllByText(/Score: 1000/);
+      expect(scoreElements.length).toBeGreaterThanOrEqual(1);
+
+      vi.restoreAllMocks();
+    });
+
+    test("shows high score entry form when qualifying", () => {
+      render(<App />);
+
+      // Start a Small game to set score to 1000
+      const smallBtns = screen.getAllByText(/Small game/i);
+      act(() => {
+        smallBtns[smallBtns.length - 1].click();
+      });
+
+      vi.spyOn(gameLogic, "populateMimes").mockImplementation(
+        (entries: [Coordinate, GameSquare][]) =>
+          new Map<Coordinate, GameSquare>(entries),
+      );
+      vi.spyOn(gameLogic, "processSquareClick").mockReturnValue({
+        openedCount: 90,
+        lost: false,
+      });
+      vi.spyOn(gameLogic, "isWin").mockReturnValue(true);
+
+      act(() => {
+        fireEvent.click(screen.getByTestId("square-0|0"));
+      });
+
+      expect(screen.getByText("New High Score!")).toBeInTheDocument();
+      expect(screen.getByPlaceholderText("Your name")).toBeInTheDocument();
+
+      vi.restoreAllMocks();
+    });
+
+    test("submit score button is disabled when name is empty", () => {
+      render(<App />);
+
+      // Start a Small game to set score to 1000
+      const smallBtns = screen.getAllByText(/Small game/i);
+      act(() => {
+        smallBtns[smallBtns.length - 1].click();
+      });
+
+      vi.spyOn(gameLogic, "populateMimes").mockImplementation(
+        (entries: [Coordinate, GameSquare][]) =>
+          new Map<Coordinate, GameSquare>(entries),
+      );
+      vi.spyOn(gameLogic, "processSquareClick").mockReturnValue({
+        openedCount: 90,
+        lost: false,
+      });
+      vi.spyOn(gameLogic, "isWin").mockReturnValue(true);
+
+      act(() => {
+        fireEvent.click(screen.getByTestId("square-0|0"));
+      });
+
+      const submitBtn = screen.getByText("Submit Score");
+      expect(submitBtn).toBeDisabled();
+
+      vi.restoreAllMocks();
+    });
+  });
+
   describe("game over overlay", () => {
     function triggerGameOver() {
       vi.spyOn(gameLogic, "populateMimes").mockImplementation(

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -57,7 +57,8 @@ function DifficultyButtons({ onRestart }: DifficultyButtonsProps) {
 
 function App() {
   const [state, dispatch] = useReducer(gameReducer, initialState);
-  const { game, boardSize, status, numFlags, playTime, showRules } = state;
+  const { game, boardSize, status, numFlags, playTime, showRules, score } =
+    state;
 
   const isGameOver = status === "gameOverLost" || status === "gameOverWon";
 
@@ -136,6 +137,9 @@ function App() {
             <h4>
               GAME OVER! You {status === "gameOverLost" ? "Lost :(" : "Won! :)"}
             </h4>
+            {status === "gameOverWon" && (
+              <h2 className="final-score">Score: {score}</h2>
+            )}
             <img
               alt="Game Over!"
               src={gameOverImage}
@@ -161,7 +165,7 @@ function App() {
       </h4>
       <h4>
         <small>
-          Play time: {playTime}s | Flags Remaining:{" "}
+          Play time: {playTime}s | Score: {score} | Flags Remaining:{" "}
           {numFlags < 0 ? "No more left!" : numFlags}
         </small>
       </h4>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,11 @@
-import { useCallback, useEffect, useMemo, useReducer } from "react";
+import { useCallback, useEffect, useMemo, useReducer, useState } from "react";
 import { Layer, Stage } from "react-konva";
-import type { Coordinate, EventType } from "types.d";
+import type { Coordinate, DifficultyKey, EventType } from "types.d";
 import { GridSize, MimeSize } from "./enums.ts";
 import { gameReducer, initialState } from "./gameReducer.ts";
+import { useScoreboard } from "./hooks/useScoreboard.ts";
 import gameOverImage from "./images/mime_color.png";
+import Scoreboard from "./Scoreboard";
 import Square from "./Square";
 import useInterval from "./useInterval";
 import { SQUARE_SIDE } from "./utils/gameLogic.ts";
@@ -55,12 +57,35 @@ function DifficultyButtons({ onRestart }: DifficultyButtonsProps) {
   );
 }
 
+function getDifficultyKey(boardSize: GridSize): DifficultyKey {
+  switch (boardSize) {
+    case GridSize.M:
+      return "M";
+    case GridSize.L:
+      return "L";
+    case GridSize.XL:
+      return "XL";
+    default:
+      return "S";
+  }
+}
+
 function App() {
   const [state, dispatch] = useReducer(gameReducer, initialState);
   const { game, boardSize, status, numFlags, playTime, showRules, score } =
     state;
 
+  const { getScores, isHighScore, addScore } = useScoreboard();
+  const [showScoreboard, setShowScoreboard] = useState(false);
+  const [playerName, setPlayerName] = useState("");
+  const [scoreSubmitted, setScoreSubmitted] = useState(false);
+
   const isGameOver = status === "gameOverLost" || status === "gameOverWon";
+  const difficultyKey = getDifficultyKey(boardSize);
+  const qualifiesForHighScore =
+    status === "gameOverWon" &&
+    !scoreSubmitted &&
+    isHighScore(difficultyKey, score);
 
   const handleSquareSelect = useCallback(
     (coOrd: Coordinate, type: EventType): void => {
@@ -82,6 +107,8 @@ function App() {
   const handleRestart = useCallback(
     (mimes: MimeSize = MimeSize.S, size: GridSize = GridSize.S): void => {
       dispatch({ type: "START_GAME", boardSize: size, numMimes: mimes });
+      setPlayerName("");
+      setScoreSubmitted(false);
     },
     [],
   );
@@ -131,6 +158,12 @@ function App() {
           </div>
         </div>
       ) : null}
+      {showScoreboard ? (
+        <Scoreboard
+          getScores={getScores}
+          onClose={() => setShowScoreboard(false)}
+        />
+      ) : null}
       {isGameOver ? (
         <div className="overlay">
           <div className="content">
@@ -138,7 +171,33 @@ function App() {
               GAME OVER! You {status === "gameOverLost" ? "Lost :(" : "Won! :)"}
             </h4>
             {status === "gameOverWon" && (
-              <h2 className="final-score">Score: {score}</h2>
+              <>
+                <h2 className="final-score">Score: {score}</h2>
+                {qualifiesForHighScore ? (
+                  <div className="high-score-entry">
+                    <p>New High Score!</p>
+                    <input
+                      type="text"
+                      maxLength={10}
+                      placeholder="Your name"
+                      value={playerName}
+                      onChange={(e) => setPlayerName(e.target.value)}
+                    />
+                    <button
+                      type="button"
+                      disabled={playerName.trim().length === 0}
+                      onClick={() => {
+                        addScore(difficultyKey, playerName.trim(), score);
+                        setScoreSubmitted(true);
+                      }}
+                    >
+                      Submit Score
+                    </button>
+                  </div>
+                ) : scoreSubmitted ? (
+                  <p>Score saved!</p>
+                ) : null}
+              </>
             )}
             <img
               alt="Game Over!"
@@ -161,6 +220,14 @@ function App() {
           }}
         >
           How to play
+        </button>{" "}
+        <button
+          type="button"
+          onClick={() => {
+            setShowScoreboard(true);
+          }}
+        >
+          Scoreboard
         </button>
       </h4>
       <h4>
@@ -191,6 +258,8 @@ function App() {
               adjacentMimes={square.adjacentMimes}
               opened={square.opened}
               flagged={square.flagged}
+              clickedMime={square.clickedMime}
+              wrongFlag={square.wrongFlag}
               isGameOver={isGameOver}
               onSelect={handleSquareSelect}
               onRightClick={handleSquareSelect}

--- a/src/Scoreboard.spec.tsx
+++ b/src/Scoreboard.spec.tsx
@@ -1,0 +1,55 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import type { DifficultyKey, ScoreEntry } from "types.d";
+import Scoreboard from "./Scoreboard";
+
+function createMockScores(): Record<DifficultyKey, ScoreEntry[]> {
+  return {
+    S: [
+      { name: "AAA", score: 900 },
+      { name: "BBB", score: 800 },
+    ],
+    M: [{ name: "CCC", score: 5000 }],
+    L: [],
+    XL: [{ name: "DDD", score: 15000 }],
+  };
+}
+
+describe("Scoreboard", () => {
+  test("renders heading", () => {
+    const scores = createMockScores();
+    render(<Scoreboard getScores={(d) => scores[d]} onClose={vi.fn()} />);
+    expect(screen.getByText("Top 10 Scores")).toBeInTheDocument();
+  });
+
+  test("shows Small scores by default", () => {
+    const scores = createMockScores();
+    render(<Scoreboard getScores={(d) => scores[d]} onClose={vi.fn()} />);
+    expect(screen.getByText("AAA")).toBeInTheDocument();
+    expect(screen.getByText("900")).toBeInTheDocument();
+  });
+
+  test("switches to Medium scores on tab click", () => {
+    const scores = createMockScores();
+    render(<Scoreboard getScores={(d) => scores[d]} onClose={vi.fn()} />);
+    fireEvent.click(screen.getByText("Medium"));
+    expect(screen.getByText("CCC")).toBeInTheDocument();
+    expect(screen.getByText("5000")).toBeInTheDocument();
+  });
+
+  test("calls onClose when Close button is clicked", () => {
+    const scores = createMockScores();
+    const onClose = vi.fn();
+    render(<Scoreboard getScores={(d) => scores[d]} onClose={onClose} />);
+    fireEvent.click(screen.getByText("Close"));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  test("renders all four difficulty tabs", () => {
+    const scores = createMockScores();
+    render(<Scoreboard getScores={(d) => scores[d]} onClose={vi.fn()} />);
+    expect(screen.getByText("Small")).toBeInTheDocument();
+    expect(screen.getByText("Medium")).toBeInTheDocument();
+    expect(screen.getByText("Large")).toBeInTheDocument();
+    expect(screen.getByText("XL")).toBeInTheDocument();
+  });
+});

--- a/src/Scoreboard.tsx
+++ b/src/Scoreboard.tsx
@@ -1,0 +1,61 @@
+import { useCallback, useState } from "react";
+import type { DifficultyKey, ScoreEntry } from "types.d";
+
+const DIFFICULTY_LABELS: Record<DifficultyKey, string> = {
+  S: "Small",
+  M: "Medium",
+  L: "Large",
+  XL: "XL",
+};
+
+const DIFFICULTY_KEYS: DifficultyKey[] = ["S", "M", "L", "XL"];
+
+interface ScoreboardProps {
+  getScores: (difficulty: DifficultyKey) => ScoreEntry[];
+  onClose: () => void;
+}
+
+function Scoreboard({ getScores, onClose }: ScoreboardProps) {
+  const [activeDifficulty, setActiveDifficulty] = useState<DifficultyKey>("S");
+
+  const entries = getScores(activeDifficulty);
+
+  const handleTabClick = useCallback((key: DifficultyKey) => {
+    setActiveDifficulty(key);
+  }, []);
+
+  return (
+    <div className="overlay">
+      <div className="content scoreboard">
+        <h4>Top 10 Scores</h4>
+        <div className="scoreboard-tabs">
+          {DIFFICULTY_KEYS.map((key) => (
+            <button
+              key={key}
+              type="button"
+              className={activeDifficulty === key ? "active" : ""}
+              onClick={() => handleTabClick(key)}
+            >
+              {DIFFICULTY_LABELS[key]}
+            </button>
+          ))}
+        </div>
+        <ol className="scoreboard-list">
+          {entries.map((entry, index) => (
+            <li key={`${String(index)}-${entry.name}`}>
+              <span className="scoreboard-name">{entry.name}</span>
+              <span className="scoreboard-score">{entry.score}</span>
+            </li>
+          ))}
+        </ol>
+        <div className="buttons">
+          <button type="button" onClick={onClose}>
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default Scoreboard;

--- a/src/Square.spec.tsx
+++ b/src/Square.spec.tsx
@@ -134,6 +134,39 @@ describe("Square", () => {
         ).not.toThrow();
       }
     });
+
+    test("renders revealed mine (not clicked) with white fill and mime image", () => {
+      renderSquare({
+        opened: true,
+        mime: true,
+        isGameOver: true,
+        clickedMime: false,
+      });
+      const rect = screen.getByTestId("konva-rect");
+      expect(rect.dataset.fill).toBe("#FFFFFF");
+      const images = screen.getAllByTestId("konva-image");
+      expect(images.length).toBeGreaterThanOrEqual(1);
+    });
+
+    test("renders clicked mine with red fill", () => {
+      renderSquare({
+        opened: true,
+        mime: true,
+        isGameOver: true,
+        clickedMime: true,
+      });
+      const rect = screen.getByTestId("konva-rect");
+      expect(rect.dataset.fill).toBe("#f80000");
+    });
+
+    test("renders wrong flag with X text", () => {
+      renderSquare({
+        flagged: true,
+        wrongFlag: true,
+        isGameOver: true,
+      });
+      expect(screen.getByText("X")).toBeInTheDocument();
+    });
   });
 
   describe("event handlers", () => {
@@ -195,8 +228,8 @@ describe("Square", () => {
   });
 
   describe("color states", () => {
-    test("opened mine has red fill", () => {
-      renderSquare({ opened: true, mime: true });
+    test("opened clicked mine has red fill", () => {
+      renderSquare({ opened: true, mime: true, clickedMime: true });
       const rect = screen.getByTestId("konva-rect");
       expect(rect.dataset.fill).toBe("#f80000");
     });

--- a/src/Square.tsx
+++ b/src/Square.tsx
@@ -50,19 +50,24 @@ function Square({
   flagged,
   isGameOver,
   adjacentMimes,
+  clickedMime,
+  wrongFlag,
 }: SquareProps & GameSquare) {
   const [flagImg] = useImage(flagImage, undefined, "same-origin");
   const [gameOverMime] = useImage(gameOverImage, undefined, "same-origin");
 
   const color = useMemo(() => {
-    if (opened && mime) {
+    if (opened && mime && clickedMime) {
       return mimeColor;
+    }
+    if (opened && mime) {
+      return unopenedColor;
     }
     if (opened) {
       return gradientArray[adjacentMimes];
     }
     return unopenedColor;
-  }, [opened, mime, adjacentMimes]);
+  }, [opened, mime, adjacentMimes, clickedMime]);
 
   const handleClick = useCallback(
     (e: KonvaEventObject<MouseEvent>) => {
@@ -119,7 +124,20 @@ function Square({
       {flagged && flagImg && (
         <Image image={flagImg} height={size} width={size} x={x} y={y} />
       )}
-      {opened && mime && isGameOver ? (
+      {wrongFlag && isGameOver ? (
+        <Text
+          x={x}
+          y={y}
+          width={size}
+          height={size}
+          padding={textPadding}
+          align="center"
+          text="X"
+          fontFamily="Press Start 2P"
+          fill="#f80000"
+          fontSize={14}
+        />
+      ) : opened && mime && isGameOver ? (
         <Image image={gameOverMime} height={size} width={size} x={x} y={y} />
       ) : (
         <Text

--- a/src/gameReducer.spec.ts
+++ b/src/gameReducer.spec.ts
@@ -25,6 +25,10 @@ describe("gameReducer", () => {
       expect(initialState.playTime).toBe(0);
       expect(initialState.showRules).toBe(false);
     });
+
+    test("has score initialized to 0", () => {
+      expect(initialState.score).toBe(0);
+    });
   });
 
   describe("START_GAME", () => {
@@ -93,6 +97,46 @@ describe("gameReducer", () => {
 
       expect(result.status).toBe("waitingStart");
     });
+
+    test("sets score to 1000 for GridSize.S", () => {
+      const result = gameReducer(initialState, {
+        type: "START_GAME",
+        boardSize: GridSize.S,
+        numMimes: MimeSize.S,
+      });
+
+      expect(result.score).toBe(1000);
+    });
+
+    test("sets score to 6000 for GridSize.M", () => {
+      const result = gameReducer(initialState, {
+        type: "START_GAME",
+        boardSize: GridSize.M,
+        numMimes: MimeSize.M,
+      });
+
+      expect(result.score).toBe(6000);
+    });
+
+    test("sets score to 11000 for GridSize.L", () => {
+      const result = gameReducer(initialState, {
+        type: "START_GAME",
+        boardSize: GridSize.L,
+        numMimes: MimeSize.L,
+      });
+
+      expect(result.score).toBe(11000);
+    });
+
+    test("sets score to 16000 for GridSize.XL", () => {
+      const result = gameReducer(initialState, {
+        type: "START_GAME",
+        boardSize: GridSize.XL,
+        numMimes: MimeSize.XL,
+      });
+
+      expect(result.score).toBe(16000);
+    });
   });
 
   describe("INIT_BOARD", () => {
@@ -156,6 +200,22 @@ describe("gameReducer", () => {
       const result = gameReducer(state, { type: "TICK" });
 
       expect(result.playTime).toBe(100);
+    });
+
+    test("decrements score by 5", () => {
+      const state: GameState = { ...initialState, score: 1000 };
+
+      const result = gameReducer(state, { type: "TICK" });
+
+      expect(result.score).toBe(995);
+    });
+
+    test("score does not go below 0", () => {
+      const state: GameState = { ...initialState, score: 2 };
+
+      const result = gameReducer(state, { type: "TICK" });
+
+      expect(result.score).toBe(0);
     });
   });
 

--- a/src/gameReducer.spec.ts
+++ b/src/gameReducer.spec.ts
@@ -440,6 +440,128 @@ describe("gameReducer", () => {
       expect(result.game).toBeInstanceOf(Map);
     });
 
+    describe("mine reveal on game over", () => {
+      test("reveals all unflagged mines when game is lost", () => {
+        const board = createTestBoard(3);
+        const mine1 = board.get("1|0" as Coordinate);
+        expect(mine1).toBeDefined();
+        if (mine1) mine1.mime = true;
+        const mine2 = board.get("2|0" as Coordinate);
+        expect(mine2).toBeDefined();
+        if (mine2) mine2.mime = true;
+
+        const state: GameState = {
+          ...initialState,
+          game: board,
+          status: "inProgress",
+          numMimes: MimeSize.XS,
+        };
+
+        vi.spyOn(gameLogic, "processSquareClick").mockReturnValue({
+          openedCount: 0,
+          lost: true,
+        });
+
+        const result = gameReducer(state, {
+          type: "SQUARE_CLICK",
+          coordinate: "1|0" as Coordinate,
+        });
+
+        const otherMine = result.game?.get("2|0" as Coordinate);
+        expect(otherMine?.opened).toBe(true);
+      });
+
+      test("marks clicked mine with clickedMime flag", () => {
+        const board = createTestBoard(3);
+        const mine = board.get("1|0" as Coordinate);
+        expect(mine).toBeDefined();
+        if (mine) mine.mime = true;
+
+        const state: GameState = {
+          ...initialState,
+          game: board,
+          status: "inProgress",
+          numMimes: MimeSize.XS,
+        };
+
+        vi.spyOn(gameLogic, "processSquareClick").mockReturnValue({
+          openedCount: 0,
+          lost: true,
+        });
+
+        const result = gameReducer(state, {
+          type: "SQUARE_CLICK",
+          coordinate: "1|0" as Coordinate,
+        });
+
+        const clickedMine = result.game?.get("1|0" as Coordinate);
+        expect(clickedMine?.clickedMime).toBe(true);
+      });
+
+      test("marks wrongly flagged non-mine squares", () => {
+        const board = createTestBoard(3);
+        const mine = board.get("1|0" as Coordinate);
+        expect(mine).toBeDefined();
+        if (mine) mine.mime = true;
+        const wrongSquare = board.get("0|1" as Coordinate);
+        expect(wrongSquare).toBeDefined();
+        if (wrongSquare) wrongSquare.flagged = true;
+
+        const state: GameState = {
+          ...initialState,
+          game: board,
+          status: "inProgress",
+          numMimes: MimeSize.XS,
+        };
+
+        vi.spyOn(gameLogic, "processSquareClick").mockReturnValue({
+          openedCount: 0,
+          lost: true,
+        });
+
+        const result = gameReducer(state, {
+          type: "SQUARE_CLICK",
+          coordinate: "1|0" as Coordinate,
+        });
+
+        const wrong = result.game?.get("0|1" as Coordinate);
+        expect(wrong?.wrongFlag).toBe(true);
+      });
+
+      test("does not mark correctly flagged mines as wrongFlag", () => {
+        const board = createTestBoard(3);
+        const mine1 = board.get("1|0" as Coordinate);
+        expect(mine1).toBeDefined();
+        if (mine1) mine1.mime = true;
+        const mine2 = board.get("2|0" as Coordinate);
+        expect(mine2).toBeDefined();
+        if (mine2) {
+          mine2.mime = true;
+          mine2.flagged = true;
+        }
+
+        const state: GameState = {
+          ...initialState,
+          game: board,
+          status: "inProgress",
+          numMimes: MimeSize.XS,
+        };
+
+        vi.spyOn(gameLogic, "processSquareClick").mockReturnValue({
+          openedCount: 0,
+          lost: true,
+        });
+
+        const result = gameReducer(state, {
+          type: "SQUARE_CLICK",
+          coordinate: "1|0" as Coordinate,
+        });
+
+        const correctFlag = result.game?.get("2|0" as Coordinate);
+        expect(correctFlag?.wrongFlag).toBeUndefined();
+      });
+    });
+
     test("does not mutate original state.game during inProgress click", () => {
       const board = createTestBoard(3);
       const originalSquare = board.get("0|0" as Coordinate);

--- a/src/gameReducer.ts
+++ b/src/gameReducer.ts
@@ -54,6 +54,21 @@ function cloneGame(
   return clone;
 }
 
+function revealMinesOnLoss(
+  game: Map<Coordinate, GameSquare>,
+  clickedCoord: Coordinate,
+): void {
+  for (const [coord, square] of game) {
+    if (coord === clickedCoord) {
+      square.clickedMime = true;
+    } else if (square.mime && !square.flagged) {
+      square.opened = true;
+    } else if (!square.mime && square.flagged) {
+      square.wrongFlag = true;
+    }
+  }
+}
+
 export function gameReducer(state: GameState, action: GameAction): GameState {
   switch (action.type) {
     case "START_GAME":
@@ -123,6 +138,7 @@ export function gameReducer(state: GameState, action: GameAction): GameState {
 
       if (result.lost) {
         nextStatus = "gameOverLost";
+        revealMinesOnLoss(nextGame, action.coordinate);
       }
 
       const newOpenSpaces = state.numOpenSpaces + result.openedCount;
@@ -178,6 +194,7 @@ export function gameReducer(state: GameState, action: GameAction): GameState {
       let nextStatus: GameStatus = state.status;
       if (result.lost) {
         nextStatus = "gameOverLost";
+        revealMinesOnLoss(nextGame, action.coordinate);
       }
 
       const newOpenSpaces = state.numOpenSpaces + result.openedCount;

--- a/src/gameReducer.ts
+++ b/src/gameReducer.ts
@@ -9,6 +9,7 @@ import {
   processSquareClick,
   SQUARE_SIDE,
 } from "./utils/gameLogic.ts";
+import { decrementScore, getBaseScore } from "./utils/score.ts";
 
 export interface GameState {
   game: Map<Coordinate, GameSquare> | null;
@@ -18,6 +19,7 @@ export interface GameState {
   numFlags: number;
   numOpenSpaces: number;
   playTime: number;
+  score: number;
   showRules: boolean;
 }
 
@@ -38,6 +40,7 @@ export const initialState: GameState = {
   numFlags: MimeSize.S,
   numOpenSpaces: 0,
   playTime: 0,
+  score: 0,
   showRules: false,
 };
 
@@ -62,6 +65,7 @@ export function gameReducer(state: GameState, action: GameAction): GameState {
         numFlags: action.numMimes,
         numOpenSpaces: 0,
         playTime: 0,
+        score: getBaseScore(action.boardSize),
       };
 
     case "INIT_BOARD": {
@@ -75,7 +79,11 @@ export function gameReducer(state: GameState, action: GameAction): GameState {
     }
 
     case "TICK":
-      return { ...state, playTime: state.playTime + 1 };
+      return {
+        ...state,
+        playTime: state.playTime + 1,
+        score: decrementScore(state.score),
+      };
 
     case "TOGGLE_RULES":
       return { ...state, showRules: !state.showRules };

--- a/src/hooks/useScoreboard.spec.ts
+++ b/src/hooks/useScoreboard.spec.ts
@@ -1,0 +1,95 @@
+import { act, renderHook } from "@testing-library/react";
+import { useScoreboard } from "./useScoreboard.ts";
+
+describe("useScoreboard", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  test("initializes with default scoreboard entries", () => {
+    const { result } = renderHook(() => useScoreboard());
+    const smallScores = result.current.getScores("S");
+    expect(smallScores).toHaveLength(10);
+    expect(smallScores[0]).toEqual({ name: "JMS", score: 100 });
+  });
+
+  test("each difficulty has its own default entries", () => {
+    const { result } = renderHook(() => useScoreboard());
+    for (const key of ["S", "M", "L", "XL"] as const) {
+      expect(result.current.getScores(key)).toHaveLength(10);
+    }
+  });
+
+  test("persists defaults to localStorage on first load", () => {
+    renderHook(() => useScoreboard());
+    const stored = localStorage.getItem("mimesweeper-scoreboard");
+    expect(stored).not.toBeNull();
+    const parsed = JSON.parse(stored as string);
+    expect(parsed.S).toHaveLength(10);
+  });
+
+  test("isHighScore returns true when score beats lowest entry", () => {
+    const { result } = renderHook(() => useScoreboard());
+    expect(result.current.isHighScore("S", 200)).toBe(true);
+  });
+
+  test("isHighScore returns false when score is at or below lowest", () => {
+    const { result } = renderHook(() => useScoreboard());
+    expect(result.current.isHighScore("S", 50)).toBe(false);
+  });
+
+  test("isHighScore returns false when score equals lowest", () => {
+    const { result } = renderHook(() => useScoreboard());
+    expect(result.current.isHighScore("S", 100)).toBe(false);
+  });
+
+  test("addScore inserts entry in sorted order", () => {
+    const { result } = renderHook(() => useScoreboard());
+    act(() => {
+      result.current.addScore("S", "ACE", 500);
+    });
+    const scores = result.current.getScores("S");
+    expect(scores[0]).toEqual({ name: "ACE", score: 500 });
+    expect(scores).toHaveLength(10);
+  });
+
+  test("addScore persists to localStorage", () => {
+    const { result } = renderHook(() => useScoreboard());
+    act(() => {
+      result.current.addScore("M", "PRO", 9999);
+    });
+    const stored = localStorage.getItem("mimesweeper-scoreboard");
+    expect(stored).not.toBeNull();
+    const parsed = JSON.parse(stored as string);
+    expect(parsed.M[0]).toEqual({ name: "PRO", score: 9999 });
+  });
+
+  test("addScore trims list to 10 entries", () => {
+    const { result } = renderHook(() => useScoreboard());
+    act(() => {
+      result.current.addScore("S", "NEW", 500);
+    });
+    expect(result.current.getScores("S")).toHaveLength(10);
+  });
+
+  test("loads existing scores from localStorage", () => {
+    const custom = {
+      S: [{ name: "TOP", score: 9999 }],
+      M: [],
+      L: [],
+      XL: [],
+    };
+    localStorage.setItem("mimesweeper-scoreboard", JSON.stringify(custom));
+    const { result } = renderHook(() => useScoreboard());
+    expect(result.current.getScores("S")[0]).toEqual({
+      name: "TOP",
+      score: 9999,
+    });
+  });
+
+  test("falls back to defaults on corrupted localStorage", () => {
+    localStorage.setItem("mimesweeper-scoreboard", "not-json{{{");
+    const { result } = renderHook(() => useScoreboard());
+    expect(result.current.getScores("S")).toHaveLength(10);
+  });
+});

--- a/src/hooks/useScoreboard.ts
+++ b/src/hooks/useScoreboard.ts
@@ -1,0 +1,73 @@
+import { useCallback, useState } from "react";
+import type { DifficultyKey, ScoreboardData, ScoreEntry } from "types.d";
+
+const STORAGE_KEY = "mimesweeper-scoreboard";
+const MAX_ENTRIES = 10;
+
+const DEFAULT_ENTRY: ScoreEntry = { name: "JMS", score: 100 };
+
+function createDefaultScoreboard(): ScoreboardData {
+  const entries = Array.from({ length: MAX_ENTRIES }, () => ({
+    ...DEFAULT_ENTRY,
+  }));
+  return {
+    S: entries.map((e) => ({ ...e })),
+    M: entries.map((e) => ({ ...e })),
+    L: entries.map((e) => ({ ...e })),
+    XL: entries.map((e) => ({ ...e })),
+  };
+}
+
+function loadScoreboard(): ScoreboardData {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored) {
+      return JSON.parse(stored) as ScoreboardData;
+    }
+  } catch {
+    // Corrupted data — fall back to defaults
+  }
+  const defaults = createDefaultScoreboard();
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(defaults));
+  return defaults;
+}
+
+function saveScoreboard(data: ScoreboardData): void {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+}
+
+export function useScoreboard() {
+  const [scores, setScores] = useState<ScoreboardData>(loadScoreboard);
+
+  const getScores = useCallback(
+    (difficulty: DifficultyKey): ScoreEntry[] => {
+      return scores[difficulty];
+    },
+    [scores],
+  );
+
+  const isHighScore = useCallback(
+    (difficulty: DifficultyKey, score: number): boolean => {
+      const entries = scores[difficulty];
+      if (entries.length < MAX_ENTRIES) return true;
+      return score > entries[entries.length - 1].score;
+    },
+    [scores],
+  );
+
+  const addScore = useCallback(
+    (difficulty: DifficultyKey, name: string, score: number): void => {
+      setScores((prev) => {
+        const entries = [...prev[difficulty], { name, score }];
+        entries.sort((a, b) => b.score - a.score);
+        const trimmed = entries.slice(0, MAX_ENTRIES);
+        const next = { ...prev, [difficulty]: trimmed };
+        saveScoreboard(next);
+        return next;
+      });
+    },
+    [],
+  );
+
+  return { scores, getScores, isHighScore, addScore };
+}

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -44,3 +44,12 @@ export interface FlaggedAdjacentProps {
   location: Coordinate;
   upcomingGame: Map<Coordinate, GameSquare>;
 }
+
+export interface ScoreEntry {
+  name: string;
+  score: number;
+}
+
+export type DifficultyKey = "S" | "M" | "L" | "XL";
+
+export type ScoreboardData = Record<DifficultyKey, ScoreEntry[]>;

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -14,6 +14,10 @@ export interface GameSquare {
   x: number;
   // Starting Y value of the square
   y: number;
+  // Was this the mime that the player clicked? (game over indicator)
+  clickedMime?: boolean;
+  // Was this square incorrectly flagged? (not actually a mime)
+  wrongFlag?: boolean;
 }
 
 // Takes an x and y position and generates a coordinate. Example generated key: x=5, y=4, returns '5|4'

--- a/src/utils/score.spec.ts
+++ b/src/utils/score.spec.ts
@@ -1,0 +1,38 @@
+import { GridSize } from "../enums.ts";
+import { decrementScore, getBaseScore } from "./score.ts";
+
+describe("getBaseScore", () => {
+  test("returns 1000 for GridSize.XS", () => {
+    expect(getBaseScore(GridSize.XS)).toBe(1000);
+  });
+
+  test("returns 1000 for GridSize.S (small)", () => {
+    expect(getBaseScore(GridSize.S)).toBe(1000);
+  });
+
+  test("returns 6000 for GridSize.M (medium)", () => {
+    expect(getBaseScore(GridSize.M)).toBe(6000);
+  });
+
+  test("returns 11000 for GridSize.L (large)", () => {
+    expect(getBaseScore(GridSize.L)).toBe(11000);
+  });
+
+  test("returns 16000 for GridSize.XL", () => {
+    expect(getBaseScore(GridSize.XL)).toBe(16000);
+  });
+});
+
+describe("decrementScore", () => {
+  test("decrements by 5", () => {
+    expect(decrementScore(1000)).toBe(995);
+  });
+
+  test("floors at 0", () => {
+    expect(decrementScore(3)).toBe(0);
+  });
+
+  test("returns 0 when already 0", () => {
+    expect(decrementScore(0)).toBe(0);
+  });
+});

--- a/src/utils/score.ts
+++ b/src/utils/score.ts
@@ -1,0 +1,22 @@
+import { GridSize } from "../enums.ts";
+
+const BASE_SCORE = 1000;
+const MULTIPLIER = 5;
+const DECREMENT_PER_SECOND = 5;
+
+const difficultyMultiplier: Record<GridSize, number> = {
+  [GridSize.XS]: 0,
+  [GridSize.S]: 0,
+  [GridSize.M]: 1,
+  [GridSize.L]: 2,
+  [GridSize.XL]: 3,
+};
+
+export function getBaseScore(gridSize: GridSize): number {
+  const mult = difficultyMultiplier[gridSize] ?? 0;
+  return BASE_SCORE + BASE_SCORE * MULTIPLIER * mult;
+}
+
+export function decrementScore(currentScore: number): number {
+  return Math.max(0, currentScore - DECREMENT_PER_SECOND);
+}


### PR DESCRIPTION
## Summary
- **Mine reveal on game over:** When the player clicks a mine, all remaining mines are revealed (white background), the clicked mine stays red, and incorrectly flagged squares show an "X" overlay
- **Score system:** Base score varies by difficulty (S=1000, M=6000, L=11000, XL=16000) and decrements by 5 each second, displayed live in the header and prominently in the win overlay
- **Top 10 scoreboard:** Per-difficulty leaderboard persisted in localStorage, accessible via a "Scoreboard" button, with high-score entry on win (default entries: "JMS" / 100)

## Test plan
- [x] 230 tests passing (45 new tests added)
- [ ] Manual: Click a mine → verify all mines revealed with correct styling (clicked=red, others=white, wrong flags=X)
- [ ] Manual: Win a game → verify score appears in overlay and high-score entry form works
- [ ] Manual: Submit a high score → verify it persists across page refresh via localStorage
- [ ] Manual: Click "Scoreboard" button → verify overlay with difficulty tabs works
- [ ] CI: Verify Node 22.x and 24.x matrix passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)