### PR TITLE
Mobile-responsive UI refresh

### DIFF
--- a/docs/plans/2026-03-01-mobile-responsive-implementation.md
+++ b/docs/plans/2026-03-01-mobile-responsive-implementation.md
@@ -1,0 +1,1103 @@
+# Mobile-Responsive UI Refresh Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make Mimesweeper fully playable on mobile devices with responsive layout, dynamic square sizing, touch-friendly interactions, and polished arcade styling.
+
+**Architecture:** CSS-first responsive approach using `@media` queries, `clamp()`, and `min()`. JS changes limited to dynamic square sizing (computed from viewport), a `useWindowSize` hook, long-press touch handler, and minimal markup restructuring. No new dependencies.
+
+**Tech Stack:** React 19, TypeScript 5.8, Konva 10, Vitest 4, Sass/CSS with custom properties, pnpm
+
+---
+
+### Task 1: Create `useWindowSize` Hook
+
+**Files:**
+- Create: `src/hooks/useWindowSize.ts`
+- Create: `src/hooks/useWindowSize.spec.ts`
+
+**Step 1: Write the failing test**
+
+Create `src/hooks/useWindowSize.spec.ts`:
+
+```typescript
+import { act, renderHook } from "@testing-library/react";
+import { useWindowSize } from "./useWindowSize";
+
+describe("useWindowSize", () => {
+  const originalInnerWidth = window.innerWidth;
+  const originalInnerHeight = window.innerHeight;
+
+  afterEach(() => {
+    Object.defineProperty(window, "innerWidth", {
+      writable: true,
+      value: originalInnerWidth,
+    });
+    Object.defineProperty(window, "innerHeight", {
+      writable: true,
+      value: originalInnerHeight,
+    });
+  });
+
+  test("returns current window dimensions", () => {
+    Object.defineProperty(window, "innerWidth", {
+      writable: true,
+      value: 1024,
+    });
+    Object.defineProperty(window, "innerHeight", {
+      writable: true,
+      value: 768,
+    });
+
+    const { result } = renderHook(() => useWindowSize());
+
+    expect(result.current.width).toBe(1024);
+    expect(result.current.height).toBe(768);
+  });
+
+  test("updates on window resize", () => {
+    Object.defineProperty(window, "innerWidth", {
+      writable: true,
+      value: 1024,
+    });
+
+    const { result } = renderHook(() => useWindowSize());
+    expect(result.current.width).toBe(1024);
+
+    act(() => {
+      Object.defineProperty(window, "innerWidth", {
+        writable: true,
+        value: 375,
+      });
+      window.dispatchEvent(new Event("resize"));
+    });
+
+    expect(result.current.width).toBe(375);
+  });
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `pnpm test -- --run src/hooks/useWindowSize.spec.ts`
+Expected: FAIL — module not found
+
+**Step 3: Write minimal implementation**
+
+Create `src/hooks/useWindowSize.ts`:
+
+```typescript
+import { useEffect, useState } from "react";
+
+interface WindowSize {
+  width: number;
+  height: number;
+}
+
+export function useWindowSize(): WindowSize {
+  const [size, setSize] = useState<WindowSize>({
+    width: window.innerWidth,
+    height: window.innerHeight,
+  });
+
+  useEffect(() => {
+    function handleResize() {
+      setSize({ width: window.innerWidth, height: window.innerHeight });
+    }
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, []);
+
+  return size;
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `pnpm test -- --run src/hooks/useWindowSize.spec.ts`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add src/hooks/useWindowSize.ts src/hooks/useWindowSize.spec.ts
+git commit -m "Adhoc: Added: useWindowSize hook for responsive layout"
+```
+
+---
+
+### Task 2: Create `computeSquareSide` Utility
+
+**Files:**
+- Create: `src/utils/responsive.ts`
+- Create: `src/utils/responsive.spec.ts`
+
+**Step 1: Write the failing test**
+
+Create `src/utils/responsive.spec.ts`:
+
+```typescript
+import { computeSquareSide } from "./responsive";
+
+describe("computeSquareSide", () => {
+  test("fits squares to available width when possible", () => {
+    // 390px viewport, 16px padding each side, gridSize 10
+    // available = 390 - 32 = 358, 358 / 10 = 35.8 → floor = 35
+    const result = computeSquareSide(390, 10);
+    expect(result).toBe(35);
+  });
+
+  test("clamps to MIN_SQUARE_SIZE when computed size is too small", () => {
+    // 390px viewport, gridSize 30
+    // available = 358, 358 / 30 = 11.9 → floor = 11 → clamp to 28
+    const result = computeSquareSide(390, 30);
+    expect(result).toBe(28);
+  });
+
+  test("clamps to MAX_SQUARE_SIZE when viewport is very wide", () => {
+    // 2560px viewport, gridSize 10
+    // available = 2528, 2528 / 10 = 252.8 → floor = 252 → clamp to 40
+    const result = computeSquareSide(2560, 10);
+    expect(result).toBe(40);
+  });
+
+  test("returns MIN_SQUARE_SIZE for zero viewport", () => {
+    const result = computeSquareSide(0, 10);
+    expect(result).toBe(28);
+  });
+
+  test("handles typical mobile sizes", () => {
+    // iPhone SE: 375px, Small grid (10)
+    // available = 343, 343 / 10 = 34.3 → 34
+    expect(computeSquareSide(375, 10)).toBe(34);
+
+    // iPhone SE: 375px, Medium grid (20)
+    // available = 343, 343 / 20 = 17.15 → 17 → clamp to 28
+    expect(computeSquareSide(375, 20)).toBe(28);
+  });
+
+  test("handles typical desktop sizes", () => {
+    // 1440px desktop, Small grid (10)
+    // available = 1200 (max cap), 1200 / 10 = 120 → clamp to 40
+    expect(computeSquareSide(1440, 10)).toBe(40);
+
+    // 1440px desktop, XL grid (40)
+    // available = 1200, 1200 / 40 = 30
+    expect(computeSquareSide(1440, 40)).toBe(30);
+  });
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `pnpm test -- --run src/utils/responsive.spec.ts`
+Expected: FAIL — module not found
+
+**Step 3: Write minimal implementation**
+
+Create `src/utils/responsive.ts`:
+
+```typescript
+export const MIN_SQUARE_SIZE = 28;
+export const MAX_SQUARE_SIZE = 40;
+const CONTAINER_PADDING = 32; // 16px each side
+const MAX_BOARD_WIDTH = 1200;
+
+export function computeSquareSide(
+  viewportWidth: number,
+  gridSize: number,
+): number {
+  const available = Math.min(
+    Math.max(0, viewportWidth - CONTAINER_PADDING),
+    MAX_BOARD_WIDTH,
+  );
+  const computed = Math.floor(available / gridSize);
+  return Math.max(MIN_SQUARE_SIZE, Math.min(MAX_SQUARE_SIZE, computed));
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `pnpm test -- --run src/utils/responsive.spec.ts`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add src/utils/responsive.ts src/utils/responsive.spec.ts
+git commit -m "Adhoc: Added: computeSquareSide utility for dynamic board sizing"
+```
+
+---
+
+### Task 3: Wire Dynamic Square Sizing into App
+
+**Files:**
+- Modify: `src/App.tsx` (lines 11, 15, 74-76, 123-127, 137, 243-246)
+- Modify: `src/gameReducer.ts` (lines 5, 86-94)
+- Modify: `src/App.spec.tsx` (add/update tests)
+
+**Context:** Currently `SQUARE_SIDE` is imported from `gameLogic.ts` as a fixed `25`. The reducer uses it in `INIT_BOARD` to call `newGame(state.boardSize, SQUARE_SIDE)`. We need to:
+1. Make `squareSide` part of `GameState` so the reducer can use it
+2. Pass `squareSide` in the `START_GAME` and `INIT_BOARD` actions
+3. Compute `squareSide` in `App.tsx` using `useWindowSize` + `computeSquareSide`
+
+**Step 1: Write failing tests for reducer changes**
+
+Add to `src/gameReducer.spec.ts` — find the existing `INIT_BOARD` test section and add:
+
+```typescript
+test("INIT_BOARD uses squareSide from state", () => {
+  const startState = gameReducer(initialState, {
+    type: "START_GAME",
+    boardSize: GridSize.S,
+    numMimes: MimeSize.S,
+    squareSide: 35,
+  });
+  const result = gameReducer(startState, { type: "INIT_BOARD" });
+  const firstSquare = result.game?.values().next().value;
+  // With squareSide 35 and position (1,0), x should be 35
+  // Find the square at 1|0
+  const square = result.game?.get("1|0" as Coordinate);
+  expect(square?.x).toBe(35); // 1 * 35
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `pnpm test -- --run src/gameReducer.spec.ts`
+Expected: FAIL — `squareSide` not in action type
+
+**Step 3: Update gameReducer**
+
+In `src/gameReducer.ts`:
+
+Add `squareSide` to `GameState` (after line 23):
+
+```typescript
+export interface GameState {
+  game: Map<Coordinate, GameSquare> | null;
+  boardSize: GridSize;
+  status: GameStatus;
+  numMimes: MimeSize;
+  numFlags: number;
+  numOpenSpaces: number;
+  playTime: number;
+  score: number;
+  showRules: boolean;
+  squareSide: number;
+}
+```
+
+Add `squareSide` to `START_GAME` action type (line 27):
+
+```typescript
+| { type: "START_GAME"; boardSize: GridSize; numMimes: MimeSize; squareSide: number }
+```
+
+Add `squareSide` to `initialState` (after line 44):
+
+```typescript
+squareSide: SQUARE_SIDE,
+```
+
+Update `START_GAME` case (around line 74) to include:
+
+```typescript
+squareSide: action.squareSide,
+```
+
+Update `INIT_BOARD` case (around line 90) to use `state.squareSide`:
+
+```typescript
+case "INIT_BOARD":
+  if (state.status !== "waitingStart") return state;
+  return {
+    ...state,
+    game: newGame(state.boardSize, state.squareSide),
+  };
+```
+
+**Step 4: Run gameReducer tests to verify they pass**
+
+Run: `pnpm test -- --run src/gameReducer.spec.ts`
+Expected: Existing tests may fail if they dispatch `START_GAME` without `squareSide`. Fix by adding `squareSide: 25` to all existing `START_GAME` dispatches in the test file.
+
+**Step 5: Update App.tsx to use dynamic sizing**
+
+In `src/App.tsx`:
+
+Add imports:
+
+```typescript
+import { useWindowSize } from "./hooks/useWindowSize.ts";
+import { computeSquareSide } from "./utils/responsive.ts";
+```
+
+Inside `App()`, after the `useReducer` call, add:
+
+```typescript
+const { width: viewportWidth } = useWindowSize();
+const squareSide = useMemo(
+  () => computeSquareSide(viewportWidth, boardSize),
+  [viewportWidth, boardSize],
+);
+```
+
+Update `handleRestart` to pass `squareSide`:
+
+```typescript
+const handleRestart = useCallback(
+  (mimes: MimeSize, size: GridSize) => {
+    const newSquareSide = computeSquareSide(viewportWidth, size);
+    dispatch({ type: "START_GAME", boardSize: size, numMimes: mimes, squareSide: newSquareSide });
+    setPlayerName("");
+    setScoreSubmitted(false);
+  },
+  [viewportWidth],
+);
+```
+
+Remove `import { SQUARE_SIDE } from "./utils/gameLogic.ts"` (line 11).
+
+Update the container `style` (line 137):
+
+```typescript
+style={{ maxWidth: `${squareSide * boardSize + 32}px` }}
+```
+
+Update `<Stage>` width and height (around line 244):
+
+```typescript
+<Stage
+  className="stage"
+  width={squareSide * boardSize}
+  height={squareSide * boardSize}
+>
+```
+
+Update `<Square>` size prop (around line 260):
+
+```typescript
+size={squareSide}
+```
+
+**Step 6: Update App.spec.tsx**
+
+The test mock for `Square` doesn't use `size`, so most tests should still pass. Update any tests that dispatch `START_GAME` to include `squareSide: 25`.
+
+Mock `useWindowSize` at the top of `App.spec.tsx`:
+
+```typescript
+vi.mock("./hooks/useWindowSize.ts", () => ({
+  useWindowSize: () => ({ width: 1440, height: 900 }),
+}));
+```
+
+**Step 7: Run full test suite**
+
+Run: `pnpm test`
+Expected: All 230+ tests pass
+
+**Step 8: Commit**
+
+```bash
+git add src/App.tsx src/gameReducer.ts src/App.spec.tsx src/gameReducer.spec.ts
+git commit -m "Adhoc: Modified: Wire dynamic square sizing into App and gameReducer"
+```
+
+---
+
+### Task 4: Responsive CSS Foundation
+
+**Files:**
+- Modify: `src/App.css` (major rewrite)
+- Modify: `src/index.css` (body background)
+
+**Step 1: Update `src/index.css`**
+
+Replace the `body` rule to make the background cover properly:
+
+```css
+body {
+  margin: 0;
+  font-family:
+    "Press Start 2P", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+    Oxygen, Ubuntu, Cantarell, "Fira Sans", "Droid Sans", "Helvetica Neue",
+    sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  background: url("images/bg.jpg") white no-repeat;
+  background-size: cover;
+  background-position: center;
+  overflow-x: hidden;
+}
+```
+
+**Step 2: Rewrite `src/App.css`**
+
+Replace `.container` (lines 7-11):
+
+```css
+.container {
+  width: 100%;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 1rem;
+  text-align: center;
+  box-sizing: border-box;
+}
+```
+
+Keep `.container > h4` color rule unchanged.
+
+Add responsive font scaling to the `h4`:
+
+```css
+.container > h4 {
+  color: var(--white);
+  font-size: clamp(0.6rem, 2.5vw, 1.2rem);
+  word-break: break-word;
+}
+```
+
+Update `.container button` — add touch-friendly sizing:
+
+```css
+.container button {
+  background-color: var(--button-bg-color);
+  transition: background-color 200ms;
+  border: 2px solid var(--black);
+  border-radius: 4px;
+  color: #f5f5f5ff;
+  padding: 0.75rem 1.25rem;
+  text-align: center;
+  text-decoration: none;
+  font-size: clamp(0.55rem, 1.8vw, 1rem);
+  display: inline-block;
+  font-family: "Press Start 2P", cursive;
+  min-height: 44px;
+  cursor: pointer;
+  box-shadow: inset 0 -2px 0 rgba(0, 0, 0, 0.3);
+
+  /* existing hover/focus/active/spacing rules unchanged */
+}
+```
+
+Update `.container .overlay .content` — remove fixed width, add responsive:
+
+```css
+.container .overlay .content {
+  width: 30rem;
+  max-width: 90vw;
+  max-height: 90vh;
+  height: fit-content;
+  background-color: var(--white);
+  padding: 2rem;
+  box-shadow: 0 0 1rem 0.2rem var(--black);
+  overflow-y: auto;
+  box-sizing: border-box;
+}
+
+.container .overlay .content.scoreboard {
+  width: 35rem;
+  max-width: 90vw;
+}
+```
+
+Add board scroll container:
+
+```css
+.board-scroll {
+  width: 100%;
+  overflow: auto;
+  -webkit-overflow-scrolling: touch;
+  margin: 0 auto;
+}
+```
+
+Add the media query block at the end of `App.css`:
+
+```css
+/* Mobile: < 768px */
+@media (max-width: 767px) {
+  .container {
+    padding: 0 0.5rem;
+  }
+
+  .container > h4 {
+    font-size: clamp(0.5rem, 3vw, 0.8rem);
+    margin: 0.5rem 0;
+  }
+
+  .container button {
+    padding: 0.5rem 0.75rem;
+    font-size: clamp(0.45rem, 2.5vw, 0.7rem);
+  }
+
+  .container .mimes {
+    height: 2.5rem;
+    background-size: 2.5rem;
+  }
+
+  .container .buttons {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.5rem;
+    padding: 0 0.5rem;
+  }
+
+  .container .scoreboard-tabs {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.5rem;
+  }
+
+  .container .scoreboard-list li {
+    font-size: 0.6rem;
+  }
+
+  .container .overlay .content .high-score-entry input {
+    font-size: 0.6rem;
+    max-width: 8rem;
+  }
+}
+
+/* Full-screen modals: < 1024px */
+@media (max-width: 1023px) {
+  .container .overlay .content,
+  .container .overlay .content.scoreboard {
+    width: 100%;
+    height: 100%;
+    max-width: none;
+    max-height: none;
+    border-radius: 0;
+    padding: 1.5rem;
+    box-sizing: border-box;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+  }
+}
+```
+
+**Step 3: Run lint to verify CSS is valid**
+
+Run: `pnpm run lint` and check for Stylelint issues if configured.
+
+**Step 4: Run full test suite**
+
+Run: `pnpm test`
+Expected: All tests pass (CSS changes don't affect unit tests)
+
+**Step 5: Commit**
+
+```bash
+git add src/App.css src/index.css
+git commit -m "Adhoc: Modified: Responsive CSS foundation with media queries and fluid typography"
+```
+
+---
+
+### Task 5: Restructure Header Layout in App.tsx
+
+**Files:**
+- Modify: `src/App.tsx` (lines 214-242)
+- Modify: `src/App.css` (add header-specific responsive rules)
+- Modify: `src/App.spec.tsx` (update selectors if needed)
+
+**Step 1: Update the header markup in App.tsx**
+
+Replace the current header section (lines 214-242 approximately) with semantic structure:
+
+```tsx
+<header className="game-header">
+  <h1 className="game-title">Mimesweeper</h1>
+  <nav className="game-nav">
+    <button
+      type="button"
+      onClick={() => {
+        dispatch({ type: "TOGGLE_RULES" });
+      }}
+    >
+      How to play
+    </button>
+    <button
+      type="button"
+      onClick={() => {
+        setShowScoreboard(true);
+      }}
+    >
+      Scoreboard
+    </button>
+  </nav>
+  <div className="game-stats">
+    <span>Play time: {playTime}s</span>
+    <span>Score: {score}</span>
+    <span>Flags Remaining: {numFlags}</span>
+  </div>
+</header>
+<div
+  className="mimes"
+  style={{ width: `${squareSide * boardSize}px` }}
+/>
+```
+
+**Step 2: Add header CSS to App.css**
+
+```css
+.game-header {
+  padding: 0.5rem 0;
+}
+
+.game-title {
+  color: var(--white);
+  font-size: clamp(0.8rem, 3vw, 1.5rem);
+  margin: 0.5rem 0;
+}
+
+.game-nav {
+  display: flex;
+  justify-content: center;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.game-stats {
+  color: var(--white);
+  font-size: clamp(0.45rem, 1.8vw, 0.8rem);
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 0.5rem;
+}
+
+@media (max-width: 767px) {
+  .game-stats {
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+
+  .game-nav {
+    gap: 0.25rem;
+  }
+}
+```
+
+**Step 3: Update App.spec.tsx**
+
+Tests currently query for "Play time: 0s" as part of the text. The stats are now in `<span>` elements instead of inside `<small>` within `<h4>`. Update test assertions if any use specific selectors. Most tests use `screen.getByText()` with regex, so they should work without changes. Verify by running.
+
+**Step 4: Run tests**
+
+Run: `pnpm test`
+Expected: All pass. If any fail due to text matching changes (e.g., "Play time: 0s | Score: 1000 | Flags Remaining: 10" was a single string, now split into separate spans), update the test assertions to match individual text fragments.
+
+**Step 5: Commit**
+
+```bash
+git add src/App.tsx src/App.css src/App.spec.tsx
+git commit -m "Adhoc: Refactored: Restructure header with semantic markup for responsive layout"
+```
+
+---
+
+### Task 6: Add Board Scroll Container
+
+**Files:**
+- Modify: `src/App.tsx` (wrap Stage in scroll container)
+
+**Step 1: Wrap the Stage**
+
+In `src/App.tsx`, wrap the `<Stage>` in a scrollable div:
+
+```tsx
+<div className="board-scroll">
+  <Stage
+    className="stage"
+    width={squareSide * boardSize}
+    height={squareSide * boardSize}
+  >
+    <Layer>
+      {gameEntries.map(([key, square]) => (
+        <Square
+          key={key}
+          coOrd={key}
+          size={squareSide}
+          isGameOver={isGameOver}
+          onSelect={handleSquareSelect}
+          onRightClick={handleSquareSelect}
+          onDoubleClick={handleSquareSelect}
+          {...square}
+        />
+      ))}
+    </Layer>
+  </Stage>
+</div>
+```
+
+The `.board-scroll` CSS was already added in Task 4.
+
+**Step 2: Run tests**
+
+Run: `pnpm test`
+Expected: All pass (Stage is mocked to a div, extra wrapper div doesn't affect test queries)
+
+**Step 3: Commit**
+
+```bash
+git add src/App.tsx
+git commit -m "Adhoc: Added: Board scroll container for large grids on mobile"
+```
+
+---
+
+### Task 7: Add Long-Press to Flag on Square
+
+**Files:**
+- Modify: `src/Square.tsx` (add touch handlers)
+- Modify: `src/Square.spec.tsx` (add long-press tests)
+
+**Step 1: Write the failing tests**
+
+Add to `src/Square.spec.tsx` in the "event handlers" describe block:
+
+```typescript
+describe("long-press to flag", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test("long-press triggers right-click handler", () => {
+    const onRightClick = vi.fn();
+    renderSquare({ onRightClick });
+
+    const group = screen.getByTestId("konva-group");
+    fireEvent.touchStart(group, {
+      touches: [{ clientX: 10, clientY: 10 }],
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(onRightClick).toHaveBeenCalledWith("0|0", "contextmenu");
+  });
+
+  test("short tap does not trigger flag", () => {
+    const onRightClick = vi.fn();
+    renderSquare({ onRightClick });
+
+    const group = screen.getByTestId("konva-group");
+    fireEvent.touchStart(group, {
+      touches: [{ clientX: 10, clientY: 10 }],
+    });
+    fireEvent.touchEnd(group);
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(onRightClick).not.toHaveBeenCalled();
+  });
+
+  test("moving finger cancels long-press", () => {
+    const onRightClick = vi.fn();
+    renderSquare({ onRightClick });
+
+    const group = screen.getByTestId("konva-group");
+    fireEvent.touchStart(group, {
+      touches: [{ clientX: 10, clientY: 10 }],
+    });
+    fireEvent.touchMove(group, {
+      touches: [{ clientX: 30, clientY: 30 }],
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(onRightClick).not.toHaveBeenCalled();
+  });
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `pnpm test -- --run src/Square.spec.tsx`
+Expected: FAIL — long-press does not trigger right-click
+
+**Step 3: Implement long-press in Square.tsx**
+
+Add `useRef` to imports. Inside the `Square` function, add:
+
+```typescript
+const longPressTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+const touchStartPos = useRef<{ x: number; y: number } | null>(null);
+const longPressTriggered = useRef(false);
+
+const LONG_PRESS_DURATION = 500;
+const MOVE_THRESHOLD = 10;
+
+const handleTouchStart = useCallback(
+  (e: KonvaEventObject<TouchEvent>) => {
+    const touch = e.evt.touches[0];
+    touchStartPos.current = { x: touch.clientX, y: touch.clientY };
+    longPressTriggered.current = false;
+
+    longPressTimer.current = setTimeout(() => {
+      longPressTriggered.current = true;
+      onRightClick(coOrd, "contextmenu");
+    }, LONG_PRESS_DURATION);
+  },
+  [coOrd, onRightClick],
+);
+
+const handleTouchMove = useCallback(
+  (e: KonvaEventObject<TouchEvent>) => {
+    if (!touchStartPos.current || !longPressTimer.current) return;
+    const touch = e.evt.touches[0];
+    const dx = Math.abs(touch.clientX - touchStartPos.current.x);
+    const dy = Math.abs(touch.clientY - touchStartPos.current.y);
+    if (dx > MOVE_THRESHOLD || dy > MOVE_THRESHOLD) {
+      clearTimeout(longPressTimer.current);
+      longPressTimer.current = null;
+    }
+  },
+  [],
+);
+
+const handleTouchEnd = useCallback(() => {
+  if (longPressTimer.current) {
+    clearTimeout(longPressTimer.current);
+    longPressTimer.current = null;
+  }
+}, []);
+```
+
+Update the existing `handleTap` to skip if long-press was triggered:
+
+```typescript
+const handleTap = useCallback(() => {
+  if (longPressTriggered.current) return;
+  onSelect(coOrd, "click");
+}, [coOrd, onSelect]);
+```
+
+Add the new handlers to the `<Group>` element:
+
+```tsx
+<Group
+  onClick={handleClick}
+  onDblClick={handleDblClick}
+  onContextMenu={handleContextMenu}
+  onTap={handleTap}
+  onDblTap={handleDblTap}
+  onTouchStart={handleTouchStart}
+  onTouchMove={handleTouchMove}
+  onTouchEnd={handleTouchEnd}
+>
+```
+
+**Step 4: Update the Group mock in Square.spec.tsx**
+
+The `konva-group` mock needs to forward `onTouchStart`, `onTouchMove`, `onTouchEnd`. Update the mock to forward these events:
+
+```typescript
+Group: ({ children, onTouchStart, onTouchMove, onTouchEnd, ...props }: Record<string, unknown>) => (
+  <div
+    data-testid="konva-group"
+    onTouchStart={(e) => onTouchStart?.({ evt: e.nativeEvent })}
+    onTouchMove={(e) => onTouchMove?.({ evt: e.nativeEvent })}
+    onTouchEnd={(e) => onTouchEnd?.({ evt: e.nativeEvent })}
+    /* ... existing event forwarding */
+  >
+    {children}
+  </div>
+),
+```
+
+**Step 5: Run tests**
+
+Run: `pnpm test -- --run src/Square.spec.tsx`
+Expected: PASS
+
+**Step 6: Run full test suite**
+
+Run: `pnpm test`
+Expected: All pass
+
+**Step 7: Commit**
+
+```bash
+git add src/Square.tsx src/Square.spec.tsx
+git commit -m "Adhoc: Added: Long-press to flag on mobile touch devices"
+```
+
+---
+
+### Task 8: Update "How to Play" Instructions for Touch
+
+**Files:**
+- Modify: `src/App.tsx` (rules overlay section)
+- Modify: `src/App.spec.tsx` (update/add rules tests)
+
+**Step 1: Write the failing test**
+
+Add to `src/App.spec.tsx` in the "rules overlay" describe block:
+
+```typescript
+test("shows touch instructions text", async () => {
+  render(<App />);
+  const button = screen.getByText("How to play");
+  await act(async () => {
+    fireEvent.click(button);
+  });
+
+  expect(screen.getByText(/Tap to open a space/i)).toBeInTheDocument();
+  expect(screen.getByText(/Long-press to flag/i)).toBeInTheDocument();
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `pnpm test -- --run src/App.spec.tsx`
+Expected: FAIL — text not found
+
+**Step 3: Update the rules overlay in App.tsx**
+
+Replace the `<ol>` in the rules overlay with instructions that cover both desktop and mobile:
+
+```tsx
+{showRules ? (
+  <div className="overlay">
+    <div className="content">
+      <h4>How to Play</h4>
+      <ol>
+        <li>Click or tap to open a space</li>
+        <li>Right-click or long-press to flag a space</li>
+        <li>Double-click or double-tap to open all adjacent un-flagged spaces</li>
+      </ol>
+      <div className="buttons">
+        <button
+          type="button"
+          onClick={() => {
+            dispatch({ type: "TOGGLE_RULES" });
+          }}
+        >
+          Let's play!
+        </button>
+      </div>
+    </div>
+  </div>
+) : null}
+```
+
+**Step 4: Update existing test assertions**
+
+The existing test that checks for "Left click to open a space" needs to be updated to "Click or tap to open a space". Find and update.
+
+**Step 5: Run tests**
+
+Run: `pnpm test`
+Expected: All pass
+
+**Step 6: Commit**
+
+```bash
+git add src/App.tsx src/App.spec.tsx
+git commit -m "Adhoc: Modified: How to Play instructions include touch controls"
+```
+
+---
+
+### Task 9: Prevent Context Menu on Long-Press
+
+**Files:**
+- Modify: `src/App.tsx` (add event listener to prevent mobile context menu on canvas)
+
+**Step 1: Add context menu prevention**
+
+In `App.tsx`, add a `useEffect` that prevents the default context menu on the game board to avoid mobile browser interference with long-press:
+
+```typescript
+useEffect(() => {
+  const handleContextMenu = (e: MouseEvent) => {
+    const target = e.target as HTMLElement;
+    if (target.closest(".board-scroll")) {
+      e.preventDefault();
+    }
+  };
+  document.addEventListener("contextmenu", handleContextMenu);
+  return () => document.removeEventListener("contextmenu", handleContextMenu);
+}, []);
+```
+
+**Step 2: Run tests**
+
+Run: `pnpm test`
+Expected: All pass
+
+**Step 3: Commit**
+
+```bash
+git add src/App.tsx
+git commit -m "Adhoc: Added: Prevent context menu on board for mobile long-press"
+```
+
+---
+
+### Task 10: Final Integration Verification
+
+**Step 1: Run full test suite with coverage**
+
+Run: `pnpm test -- --coverage`
+Expected: All tests pass, coverage >= 80% on all metrics
+
+**Step 2: Run linter**
+
+Run: `pnpm run lint`
+Expected: No errors
+
+**Step 3: Run markdown lint**
+
+Run: `pnpm run lint:markdown`
+Expected: No errors
+
+**Step 4: Run build**
+
+Run: `pnpm run build`
+Expected: Build succeeds with no TypeScript errors
+
+**Step 5: Manual verification checklist**
+
+Start dev server: `pnpm start`
+
+Test in Chrome DevTools device emulation:
+- [ ] iPhone SE (375px): Small game fits, squares are touch-friendly
+- [ ] iPhone 14 Pro Max (430px): Small game fits, Medium scrolls
+- [ ] iPad (768px): All sizes work, modals full-screen
+- [ ] Desktop (1440px): Current behavior preserved, modals centered cards
+- [ ] Modals go full-screen below 1024px
+- [ ] Scoreboard tabs wrap to 2x2 grid on mobile
+- [ ] DifficultyButtons wrap to 2-column grid on mobile
+- [ ] Long-press on a square opens flag (test on real device or touch emulation)
+- [ ] Header stacks vertically on mobile
+- [ ] Stats line is readable on mobile
+- [ ] No horizontal scrollbar on any mobile size
+- [ ] Board scrolls smoothly on larger grids
+
+**Step 6: Commit any fixes from manual testing**
+
+```bash
+git add -A
+git commit -m "Adhoc: BugFix: Address issues found during manual mobile testing"
+```

--- a/docs/plans/2026-03-01-mobile-responsive-ui-refresh-design.md
+++ b/docs/plans/2026-03-01-mobile-responsive-ui-refresh-design.md
@@ -1,0 +1,170 @@
+# Mobile-Responsive UI Refresh Design
+
+**Date:** 2026-03-01
+**Branch:** feature/design-refactor
+**Status:** Approved
+
+## Problem
+
+The Mimesweeper UI is unusable on mobile devices:
+
+- `.container` has `min-width: 1000px` forcing horizontal scroll on all mobile devices
+- Modal `.content` is fixed at `30rem` (480px), Scoreboard at `35rem` (560px) — both overflow on phones
+- Game squares are 25x25px, well below the 44px minimum touch target
+- Zero `@media` queries exist in the codebase
+- Header text and buttons wrap unpredictably on narrow screens
+- No mobile flagging mechanism (right-click unavailable on touch devices)
+
+## Design Decisions
+
+- **Approach:** CSS-First Responsive (media queries, `clamp()`, `min()`/`max()`)
+- **Board sizing:** Hybrid fit + zoom threshold — auto-shrink squares to fit viewport, clamp to minimum 28px, enable scroll/pan when board exceeds viewport
+- **Visual direction:** Polish current look — keep dark header, retro font, light grid, mime imagery; enhance button styling, spacing, stat display, and modals
+- **Mobile flagging:** Long-press (~500ms) to toggle flag
+
+## Breakpoints
+
+| Breakpoint | Target |
+|-----------|--------|
+| `< 768px` | Mobile (phones, small tablets) |
+| `< 1024px` | Tablet |
+| `>= 1024px` | Desktop (current behavior preserved) |
+
+## Section 1: Responsive Layout Foundation
+
+Remove the hard `min-width: 1000px` from `.container` and the inline `minWidth` style. Replace with:
+
+```css
+.container {
+  width: 100%;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 1rem;
+  box-sizing: border-box;
+  overflow-x: hidden;
+}
+```
+
+Add `overflow-x: hidden` to body/html. Make background image cover properly.
+
+## Section 2: Dynamic Square Sizing
+
+Replace fixed `SQUARE_SIDE = 25` with a computed value in `App.tsx`:
+
+```text
+availableWidth = min(window.innerWidth - padding, maxDesktopWidth)
+computedSize = floor(availableWidth / gridSize)
+squareSide = clamp(computedSize, MIN_SQUARE_SIZE, MAX_SQUARE_SIZE)
+```
+
+- `MIN_SQUARE_SIZE = 28` — floor for touch-friendliness
+- `MAX_SQUARE_SIZE = 40` — cap so desktop boards aren't absurdly large
+- Default desktop behavior: ~25px preserved when viewport is wide enough
+
+When `squareSide * gridSize > availableWidth`, the board gets a scrollable container with `-webkit-overflow-scrolling: touch`.
+
+A `useWindowSize` hook or `ResizeObserver` recalculates on resize. The `x`/`y` positions in `GameSquare` are recomputed on `START_GAME`/`INIT_BOARD`, so changing `squareSide` before dispatching is sufficient.
+
+## Section 3: Mobile Modals (Full-Screen < 1024px)
+
+On screens below 1024px, modals go full-screen:
+
+```css
+@media (max-width: 1023px) {
+  .overlay .content {
+    width: 100%;
+    height: 100%;
+    max-width: none;
+    border-radius: 0;
+    padding: 1.5rem;
+    overflow-y: auto;
+    box-sizing: border-box;
+  }
+}
+```
+
+Desktop (>= 1024px) retains the current centered card style.
+
+Scoreboard tabs stack 2x2 grid on mobile:
+
+```css
+@media (max-width: 767px) {
+  .scoreboard-tabs {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.5rem;
+  }
+}
+```
+
+## Section 4: Header & Controls Responsive Layout
+
+Restructure to vertical stack on mobile:
+
+```text
+[Mobile]                    [Desktop]
+Mimesweeper                 Mimesweeper  [How to play] [Scoreboard]
+[How to play] [Scoreboard]  Play time: 0s | Score: 1000 | Flags: 10
+Play time: 0s               [mime strip]
+Score: 1000
+Flags: 10
+[mime strip]
+```
+
+Font scaling with `clamp()`:
+
+```css
+h4 { font-size: clamp(0.7rem, 2.5vw, 1.2rem); }
+button { font-size: clamp(0.6rem, 2vw, 1rem); }
+.stats { font-size: clamp(0.5rem, 1.8vw, 0.85rem); }
+```
+
+## Section 5: Mobile Touch — Long-Press to Flag
+
+Add long-press handler to `Square.tsx`:
+
+- `onTouchStart` → start 500ms timer, record touch position
+- `onTouchEnd` / `onTouchMove` (> 10px) → cancel timer
+- Timer fires → dispatch flag toggle (same as right-click)
+- Regular `onTap` (< 500ms, no movement) → open square
+- `onDblTap` → open adjacent unflagged (existing)
+
+Prevent default context menu on long-press.
+
+Update "How to Play" to detect touch and show appropriate instructions:
+- "Tap to open a space"
+- "Long-press to flag a space"
+- "Double-tap to open all adjacent un-flagged spaces"
+
+## Section 6: Button & DifficultyButtons Styling
+
+Arcade-button polish:
+- `border-radius: 4px`
+- Subtle inset shadow for 3D pressed feel
+- `min-height: 44px` on mobile for touch targets
+- DifficultyButtons wrap to 2-column grid on mobile
+
+```css
+@media (max-width: 767px) {
+  .buttons {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.5rem;
+  }
+}
+```
+
+## Section 7: Game Board Scroll Container
+
+When board exceeds viewport width:
+
+```css
+.board-scroll {
+  width: 100%;
+  overflow: auto;
+  -webkit-overflow-scrolling: touch;
+  touch-action: pan-x pan-y;
+}
+```
+
+The Konva `<Stage>` sits inside this container for pan/scroll on larger boards.

--- a/src/App.css
+++ b/src/App.css
@@ -41,10 +41,11 @@
   border-radius: 4px;
   color: #f5f5f5ff;
   padding: 0.75rem 1.25rem;
-  text-align: center;
   text-decoration: none;
   font-size: clamp(0.55rem, 1.8vw, 1rem);
-  display: inline-block;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   font-family: "Press Start 2P", cursive;
   min-height: 44px;
   cursor: pointer;

--- a/src/App.css
+++ b/src/App.css
@@ -177,6 +177,34 @@
   max-width: 10rem;
 }
 
+.game-header {
+  padding: 0.5rem 0;
+}
+
+.game-title {
+  color: var(--white);
+  font-size: clamp(0.8rem, 3vw, 1.5rem);
+  margin: 0.5rem 0;
+}
+
+.game-nav {
+  display: flex;
+  justify-content: center;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.game-stats {
+  color: var(--white);
+  font-size: clamp(0.45rem, 1.8vw, 0.8rem);
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 0.5rem;
+}
+
 /* Mobile: < 768px */
 @media (max-width: 767px) {
   .container {
@@ -203,6 +231,15 @@
     grid-template-columns: 1fr 1fr;
     gap: 0.5rem;
     padding: 0 0.5rem;
+  }
+
+  .game-stats {
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+
+  .game-nav {
+    gap: 0.25rem;
   }
 
   .container .scoreboard-tabs {

--- a/src/App.css
+++ b/src/App.css
@@ -82,6 +82,7 @@
   width: 100%;
   overflow: auto;
   -webkit-overflow-scrolling: touch;
+  touch-action: pan-x pan-y;
   margin: 0 auto;
 }
 

--- a/src/App.css
+++ b/src/App.css
@@ -5,13 +5,18 @@
 }
 
 .container {
-  min-width: 1000px;
-  margin: auto;
+  width: 100%;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 1rem;
   text-align: center;
+  box-sizing: border-box;
 }
 
 .container > h4 {
   color: var(--white);
+  font-size: clamp(0.6rem, 2.5vw, 1.2rem);
+  word-break: break-word;
 }
 
 .container ol li + li {
@@ -33,13 +38,17 @@
   background-color: var(--button-bg-color);
   transition: background-color 200ms;
   border: 2px solid var(--black);
+  border-radius: 4px;
   color: #f5f5f5ff;
-  padding: 1rem 1.5rem;
+  padding: 0.75rem 1.25rem;
   text-align: center;
   text-decoration: none;
-  font-size: 1rem;
+  font-size: clamp(0.55rem, 1.8vw, 1rem);
   display: inline-block;
   font-family: "Press Start 2P", cursive;
+  min-height: 44px;
+  cursor: pointer;
+  box-shadow: inset 0 -2px 0 rgba(0, 0, 0, 0.3);
 
   & + button {
     margin: 0.5rem;
@@ -69,6 +78,13 @@
   margin: auto;
 }
 
+.board-scroll {
+  width: 100%;
+  overflow: auto;
+  -webkit-overflow-scrolling: touch;
+  margin: 0 auto;
+}
+
 .container .overlay {
   top: 0;
   left: 0;
@@ -84,10 +100,14 @@
 
 .container .overlay .content {
   width: 30rem;
+  max-width: 90vw;
+  max-height: 90vh;
   height: fit-content;
   background-color: var(--white);
   padding: 2rem;
   box-shadow: 0 0 1rem 0.2rem var(--black);
+  overflow-y: auto;
+  box-sizing: border-box;
 }
 
 .container .overlay .content .buttons {
@@ -101,6 +121,7 @@
 
 .container .overlay .content.scoreboard {
   width: 35rem;
+  max-width: 90vw;
 }
 
 .container .scoreboard-tabs {
@@ -154,4 +175,67 @@
   border: 2px solid var(--black);
   margin-right: 0.5rem;
   max-width: 10rem;
+}
+
+/* Mobile: < 768px */
+@media (max-width: 767px) {
+  .container {
+    padding: 0 0.5rem;
+  }
+
+  .container > h4 {
+    font-size: clamp(0.5rem, 3vw, 0.8rem);
+    margin: 0.5rem 0;
+  }
+
+  .container button {
+    padding: 0.5rem 0.75rem;
+    font-size: clamp(0.45rem, 2.5vw, 0.7rem);
+  }
+
+  .container .mimes {
+    height: 2.5rem;
+    background-size: 2.5rem;
+  }
+
+  .container .buttons {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.5rem;
+    padding: 0 0.5rem;
+  }
+
+  .container .scoreboard-tabs {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.5rem;
+  }
+
+  .container .scoreboard-list li {
+    font-size: 0.6rem;
+  }
+
+  .container .overlay .content .high-score-entry input {
+    font-size: 0.6rem;
+    max-width: 8rem;
+  }
+}
+
+/* Full-screen modals: < 1024px */
+@media (max-width: 1023px) {
+  .container .overlay .content,
+  .container .overlay .content.scoreboard {
+    width: 100%;
+    height: 100%;
+    max-width: none;
+    max-height: none;
+    border-radius: 0;
+    padding: 1.5rem;
+    box-sizing: border-box;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+  }
 }

--- a/src/App.spec.tsx
+++ b/src/App.spec.tsx
@@ -34,6 +34,10 @@ vi.mock("use-image", () => ({
   default: () => [null, "loaded"],
 }));
 
+vi.mock("./hooks/useWindowSize.ts", () => ({
+  useWindowSize: () => ({ width: 1440, height: 900 }),
+}));
+
 describe("App", () => {
   describe("initial rendering", () => {
     test("renders title", () => {

--- a/src/App.spec.tsx
+++ b/src/App.spec.tsx
@@ -101,7 +101,7 @@ describe("App", () => {
       });
       expect(screen.getByText("How to Play")).toBeInTheDocument();
       expect(
-        screen.getByText(/Left click to open a space/i),
+        screen.getByText(/Click or tap to open a space/i),
       ).toBeInTheDocument();
     });
 
@@ -114,8 +114,19 @@ describe("App", () => {
         screen.getByText(/Let's play!/i).click();
       });
       expect(
-        screen.queryByText(/Left click to open a space/i),
+        screen.queryByText(/Click or tap to open a space/i),
       ).not.toBeInTheDocument();
+    });
+
+    test("shows touch instructions text", async () => {
+      render(<App />);
+      const button = screen.getByText("How to play");
+      await act(() => {
+        fireEvent.click(button);
+      });
+
+      expect(screen.getByText(/tap to open a space/i)).toBeInTheDocument();
+      expect(screen.getByText(/long-press to flag/i)).toBeInTheDocument();
     });
   });
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,11 +4,12 @@ import type { Coordinate, DifficultyKey, EventType } from "types.d";
 import { GridSize, MimeSize } from "./enums.ts";
 import { gameReducer, initialState } from "./gameReducer.ts";
 import { useScoreboard } from "./hooks/useScoreboard.ts";
+import { useWindowSize } from "./hooks/useWindowSize.ts";
 import gameOverImage from "./images/mime_color.png";
 import Scoreboard from "./Scoreboard";
 import Square from "./Square";
 import useInterval from "./useInterval";
-import { SQUARE_SIDE } from "./utils/gameLogic.ts";
+import { computeSquareSide } from "./utils/responsive.ts";
 import "App.css";
 
 // Interval delay of the timer. Defaults to 1s (1000ms)
@@ -75,6 +76,12 @@ function App() {
   const { game, boardSize, status, numFlags, playTime, showRules, score } =
     state;
 
+  const { width: viewportWidth } = useWindowSize();
+  const squareSide = useMemo(
+    () => computeSquareSide(viewportWidth, boardSize),
+    [viewportWidth, boardSize],
+  );
+
   const { getScores, isHighScore, addScore } = useScoreboard();
   const [showScoreboard, setShowScoreboard] = useState(false);
   const [playerName, setPlayerName] = useState("");
@@ -106,11 +113,17 @@ function App() {
 
   const handleRestart = useCallback(
     (mimes: MimeSize = MimeSize.S, size: GridSize = GridSize.S): void => {
-      dispatch({ type: "START_GAME", boardSize: size, numMimes: mimes });
+      const newSquareSide = computeSquareSide(viewportWidth, size);
+      dispatch({
+        type: "START_GAME",
+        boardSize: size,
+        numMimes: mimes,
+        squareSide: newSquareSide,
+      });
       setPlayerName("");
       setScoreSubmitted(false);
     },
-    [],
+    [viewportWidth],
   );
 
   useInterval(
@@ -134,7 +147,7 @@ function App() {
   return (
     <div
       className="container"
-      style={{ minWidth: `${String(SQUARE_SIDE * boardSize)}px` }}
+      style={{ maxWidth: `${squareSide * boardSize + 32}px` }}
     >
       {showRules ? (
         <div className="overlay">
@@ -236,13 +249,10 @@ function App() {
           {numFlags < 0 ? "No more left!" : numFlags}
         </small>
       </h4>
-      <div
-        className="mimes"
-        style={{ width: `${String(SQUARE_SIDE * boardSize)}px` }}
-      />
+      <div className="mimes" style={{ width: `${squareSide * boardSize}px` }} />
       <Stage
-        width={SQUARE_SIDE * boardSize}
-        height={SQUARE_SIDE * boardSize}
+        width={squareSide * boardSize}
+        height={squareSide * boardSize}
         className="stage"
         data-test-id="stage"
       >
@@ -253,7 +263,7 @@ function App() {
               coOrd={key}
               x={square.x}
               y={square.y}
-              size={SQUARE_SIDE}
+              size={squareSide}
               mime={square.mime}
               adjacentMimes={square.adjacentMimes}
               opened={square.opened}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -135,9 +135,9 @@ function App() {
 
   useEffect(() => {
     if (status === "waitingStart" && boardSize > 0) {
-      dispatch({ type: "INIT_BOARD" });
+      dispatch({ type: "INIT_BOARD", squareSide });
     }
-  }, [status, boardSize]);
+  }, [status, boardSize, squareSide]);
 
   useEffect(() => {
     const handleContextMenu = (e: MouseEvent) => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -224,31 +224,34 @@ function App() {
           </div>
         </div>
       ) : null}
-      <h4>
-        Mimesweeper{" "}
-        <button
-          type="button"
-          onClick={() => {
-            dispatch({ type: "TOGGLE_RULES" });
-          }}
-        >
-          How to play
-        </button>{" "}
-        <button
-          type="button"
-          onClick={() => {
-            setShowScoreboard(true);
-          }}
-        >
-          Scoreboard
-        </button>
-      </h4>
-      <h4>
-        <small>
-          Play time: {playTime}s | Score: {score} | Flags Remaining:{" "}
-          {numFlags < 0 ? "No more left!" : numFlags}
-        </small>
-      </h4>
+      <header className="game-header">
+        <h1 className="game-title">Mimesweeper</h1>
+        <nav className="game-nav">
+          <button
+            type="button"
+            onClick={() => {
+              dispatch({ type: "TOGGLE_RULES" });
+            }}
+          >
+            How to play
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              setShowScoreboard(true);
+            }}
+          >
+            Scoreboard
+          </button>
+        </nav>
+        <div className="game-stats">
+          <span>Play time: {playTime}s</span>
+          <span>Score: {score}</span>
+          <span>
+            Flags Remaining: {numFlags < 0 ? "No more left!" : numFlags}
+          </span>
+        </div>
+      </header>
       <div className="mimes" style={{ width: `${squareSide * boardSize}px` }} />
       <Stage
         width={squareSide * boardSize}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -139,6 +139,17 @@ function App() {
     }
   }, [status, boardSize]);
 
+  useEffect(() => {
+    const handleContextMenu = (e: MouseEvent) => {
+      const target = e.target as HTMLElement;
+      if (target.closest(".board-scroll")) {
+        e.preventDefault();
+      }
+    };
+    document.addEventListener("contextmenu", handleContextMenu);
+    return () => document.removeEventListener("contextmenu", handleContextMenu);
+  }, []);
+
   const gameEntries = useMemo(
     () => Array.from(game ? game.entries() : []),
     [game],
@@ -154,9 +165,12 @@ function App() {
           <div className="content">
             <h4>How to Play</h4>
             <ol>
-              <li>Left click to open a space</li>
-              <li>Right click to flag a space</li>
-              <li>Double click to open all adjacent un-flagged spaces</li>
+              <li>Click or tap to open a space</li>
+              <li>Right-click or long-press to flag a space</li>
+              <li>
+                Double-click or double-tap to open all adjacent un-flagged
+                spaces
+              </li>
             </ol>
             <div className="buttons">
               <button
@@ -253,34 +267,36 @@ function App() {
         </div>
       </header>
       <div className="mimes" style={{ width: `${squareSide * boardSize}px` }} />
-      <Stage
-        width={squareSide * boardSize}
-        height={squareSide * boardSize}
-        className="stage"
-        data-test-id="stage"
-      >
-        <Layer>
-          {gameEntries.map(([key, square]) => (
-            <Square
-              key={key}
-              coOrd={key}
-              x={square.x}
-              y={square.y}
-              size={squareSide}
-              mime={square.mime}
-              adjacentMimes={square.adjacentMimes}
-              opened={square.opened}
-              flagged={square.flagged}
-              clickedMime={square.clickedMime}
-              wrongFlag={square.wrongFlag}
-              isGameOver={isGameOver}
-              onSelect={handleSquareSelect}
-              onRightClick={handleSquareSelect}
-              onDoubleClick={handleSquareSelect}
-            />
-          ))}
-        </Layer>
-      </Stage>
+      <div className="board-scroll">
+        <Stage
+          width={squareSide * boardSize}
+          height={squareSide * boardSize}
+          className="stage"
+          data-test-id="stage"
+        >
+          <Layer>
+            {gameEntries.map(([key, square]) => (
+              <Square
+                key={key}
+                coOrd={key}
+                x={square.x}
+                y={square.y}
+                size={squareSide}
+                mime={square.mime}
+                adjacentMimes={square.adjacentMimes}
+                opened={square.opened}
+                flagged={square.flagged}
+                clickedMime={square.clickedMime}
+                wrongFlag={square.wrongFlag}
+                isGameOver={isGameOver}
+                onSelect={handleSquareSelect}
+                onRightClick={handleSquareSelect}
+                onDoubleClick={handleSquareSelect}
+              />
+            ))}
+          </Layer>
+        </Stage>
+      </div>
       <p style={{ marginTop: "1rem" }}>Restart?</p>
       <div className="buttons">
         <DifficultyButtons onRestart={handleRestart} />

--- a/src/Square.spec.tsx
+++ b/src/Square.spec.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import type { Coordinate, EventType, GameSquare } from "types";
 import Square from "./Square";
 
@@ -6,8 +6,17 @@ import Square from "./Square";
 vi.mock("react-konva", () => ({
   // biome-ignore lint/suspicious/noExplicitAny: test mock requires flexible typing
   Group: (props: any) => {
-    const { onClick, onContextMenu, onDblClick, onTap, onDblTap, children } =
-      props;
+    const {
+      onClick,
+      onContextMenu,
+      onDblClick,
+      onTap,
+      onDblTap,
+      onTouchStart,
+      onTouchMove,
+      onTouchEnd,
+      children,
+    } = props;
     return (
       // biome-ignore lint/a11y/useKeyWithClickEvents: test mock for Konva canvas events
       // biome-ignore lint/a11y/noStaticElementInteractions: test mock for Konva canvas events
@@ -28,14 +37,25 @@ vi.mock("react-konva", () => ({
             onDblClick({ evt: e.nativeEvent });
           }
         }}
-        onTouchEnd={() => {
-          if (onTap) {
+        onTouchEnd={(e) => {
+          if (typeof onTouchEnd === "function") {
+            onTouchEnd({ evt: e.nativeEvent });
+          }
+          if (typeof onTap === "function") {
             onTap();
           }
         }}
-        onTouchStart={() => {
-          if (onDblTap) {
+        onTouchStart={(e: React.TouchEvent) => {
+          if (typeof onDblTap === "function") {
             onDblTap();
+          }
+          if (typeof onTouchStart === "function") {
+            onTouchStart({ evt: e.nativeEvent });
+          }
+        }}
+        onTouchMove={(e: React.TouchEvent) => {
+          if (typeof onTouchMove === "function") {
+            onTouchMove({ evt: e.nativeEvent });
           }
         }}
       >
@@ -245,6 +265,68 @@ describe("Square", () => {
     test("cleans up without error", () => {
       const { unmount } = renderSquare({ opened: true });
       expect(() => unmount()).not.toThrow();
+    });
+  });
+
+  describe("long-press to flag", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    test("long-press triggers right-click handler", () => {
+      const onRightClick = vi.fn();
+      renderSquare({ onRightClick });
+
+      const group = screen.getByTestId("konva-group");
+      fireEvent.touchStart(group, {
+        touches: [{ clientX: 10, clientY: 10 }],
+      });
+
+      act(() => {
+        vi.advanceTimersByTime(500);
+      });
+
+      expect(onRightClick).toHaveBeenCalledWith("0|0", "contextmenu");
+    });
+
+    test("short tap does not trigger flag", () => {
+      const onRightClick = vi.fn();
+      renderSquare({ onRightClick });
+
+      const group = screen.getByTestId("konva-group");
+      fireEvent.touchStart(group, {
+        touches: [{ clientX: 10, clientY: 10 }],
+      });
+      fireEvent.touchEnd(group);
+
+      act(() => {
+        vi.advanceTimersByTime(500);
+      });
+
+      expect(onRightClick).not.toHaveBeenCalled();
+    });
+
+    test("moving finger cancels long-press", () => {
+      const onRightClick = vi.fn();
+      renderSquare({ onRightClick });
+
+      const group = screen.getByTestId("konva-group");
+      fireEvent.touchStart(group, {
+        touches: [{ clientX: 10, clientY: 10 }],
+      });
+      fireEvent.touchMove(group, {
+        touches: [{ clientX: 30, clientY: 30 }],
+      });
+
+      act(() => {
+        vi.advanceTimersByTime(500);
+      });
+
+      expect(onRightClick).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/Square.tsx
+++ b/src/Square.tsx
@@ -30,6 +30,8 @@ const shadowColor = "#000000";
 const shadowBlurSize = 7;
 const textPadding = 5;
 const gradientMidpoint = 4;
+const LONG_PRESS_DURATION = 500;
+const MOVE_THRESHOLD = 10;
 
 // Hoisted to module scope — inputs are constants, no need to recompute
 const gradientArray = new Gradient()
@@ -59,9 +61,6 @@ function Square({
   const longPressTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const touchStartPos = useRef<{ x: number; y: number } | null>(null);
   const longPressTriggered = useRef(false);
-
-  const LONG_PRESS_DURATION = 500;
-  const MOVE_THRESHOLD = 10;
 
   const color = useMemo(() => {
     if (opened && mime && clickedMime) {

--- a/src/Square.tsx
+++ b/src/Square.tsx
@@ -175,6 +175,7 @@ function Square({
           height={size}
           padding={textPadding}
           align="center"
+          verticalAlign="middle"
           text="X"
           fontFamily="Press Start 2P"
           fill="#f80000"
@@ -190,6 +191,7 @@ function Square({
           height={size}
           padding={textPadding}
           align="center"
+          verticalAlign="middle"
           text={opened ? String(adjacentMimes) : ``}
           fontFamily="Press Start 2P"
         />

--- a/src/Square.tsx
+++ b/src/Square.tsx
@@ -32,6 +32,8 @@ const textPadding = 5;
 const gradientMidpoint = 4;
 const LONG_PRESS_DURATION = 500;
 const MOVE_THRESHOLD = 10;
+const HOVER_OPACITY = 0.85;
+const ACTIVE_OPACITY = 0.7;
 
 // Hoisted to module scope — inputs are constants, no need to recompute
 const gradientArray = new Gradient()
@@ -58,6 +60,7 @@ function Square({
   const [flagImg] = useImage(flagImage, undefined, "same-origin");
   const [gameOverMime] = useImage(gameOverImage, undefined, "same-origin");
 
+  const rectRef = useRef<Konva.Rect>(null);
   const longPressTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const touchStartPos = useRef<{ x: number; y: number } | null>(null);
   const longPressTriggered = useRef(false);
@@ -144,6 +147,30 @@ function Square({
     }
   }, []);
 
+  const setRectOpacity = useCallback((opacity: number) => {
+    const node = rectRef.current;
+    if (node) {
+      node.opacity(opacity);
+      node.getLayer()?.batchDraw();
+    }
+  }, []);
+
+  const handleMouseEnter = useCallback(() => {
+    if (!opened) setRectOpacity(HOVER_OPACITY);
+  }, [opened, setRectOpacity]);
+
+  const handleMouseLeave = useCallback(() => {
+    setRectOpacity(1);
+  }, [setRectOpacity]);
+
+  const handleMouseDown = useCallback(() => {
+    if (!opened) setRectOpacity(ACTIVE_OPACITY);
+  }, [opened, setRectOpacity]);
+
+  const handleMouseUp = useCallback(() => {
+    if (!opened) setRectOpacity(HOVER_OPACITY);
+  }, [opened, setRectOpacity]);
+
   return (
     <Group
       onClick={handleClick}
@@ -154,8 +181,13 @@ function Square({
       onTouchStart={handleTouchStart}
       onTouchMove={handleTouchMove}
       onTouchEnd={handleTouchEnd}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+      onMouseDown={handleMouseDown}
+      onMouseUp={handleMouseUp}
     >
       <Rect
+        ref={rectRef}
         x={x}
         y={y}
         width={size}

--- a/src/Square.tsx
+++ b/src/Square.tsx
@@ -32,8 +32,6 @@ const textPadding = 5;
 const gradientMidpoint = 4;
 const LONG_PRESS_DURATION = 500;
 const MOVE_THRESHOLD = 10;
-const HOVER_OPACITY = 0.85;
-const ACTIVE_OPACITY = 0.7;
 
 // Hoisted to module scope — inputs are constants, no need to recompute
 const gradientArray = new Gradient()
@@ -60,7 +58,6 @@ function Square({
   const [flagImg] = useImage(flagImage, undefined, "same-origin");
   const [gameOverMime] = useImage(gameOverImage, undefined, "same-origin");
 
-  const rectRef = useRef<Konva.Rect>(null);
   const longPressTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const touchStartPos = useRef<{ x: number; y: number } | null>(null);
   const longPressTriggered = useRef(false);
@@ -147,30 +144,6 @@ function Square({
     }
   }, []);
 
-  const setRectOpacity = useCallback((opacity: number) => {
-    const node = rectRef.current;
-    if (node) {
-      node.opacity(opacity);
-      node.getLayer()?.batchDraw();
-    }
-  }, []);
-
-  const handleMouseEnter = useCallback(() => {
-    if (!opened) setRectOpacity(HOVER_OPACITY);
-  }, [opened, setRectOpacity]);
-
-  const handleMouseLeave = useCallback(() => {
-    setRectOpacity(1);
-  }, [setRectOpacity]);
-
-  const handleMouseDown = useCallback(() => {
-    if (!opened) setRectOpacity(ACTIVE_OPACITY);
-  }, [opened, setRectOpacity]);
-
-  const handleMouseUp = useCallback(() => {
-    if (!opened) setRectOpacity(HOVER_OPACITY);
-  }, [opened, setRectOpacity]);
-
   return (
     <Group
       onClick={handleClick}
@@ -181,13 +154,8 @@ function Square({
       onTouchStart={handleTouchStart}
       onTouchMove={handleTouchMove}
       onTouchEnd={handleTouchEnd}
-      onMouseEnter={handleMouseEnter}
-      onMouseLeave={handleMouseLeave}
-      onMouseDown={handleMouseDown}
-      onMouseUp={handleMouseUp}
     >
       <Rect
-        ref={rectRef}
         x={x}
         y={y}
         width={size}

--- a/src/Square.tsx
+++ b/src/Square.tsx
@@ -1,6 +1,6 @@
 import Gradient from "javascript-color-gradient";
 import type Konva from "konva";
-import { useCallback, useMemo } from "react";
+import { useCallback, useMemo, useRef } from "react";
 import { Group, Image, Rect, Text } from "react-konva";
 import type { Coordinate, EventType, GameSquare } from "types";
 import useImage from "use-image";
@@ -56,6 +56,13 @@ function Square({
   const [flagImg] = useImage(flagImage, undefined, "same-origin");
   const [gameOverMime] = useImage(gameOverImage, undefined, "same-origin");
 
+  const longPressTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const touchStartPos = useRef<{ x: number; y: number } | null>(null);
+  const longPressTriggered = useRef(false);
+
+  const LONG_PRESS_DURATION = 500;
+  const MOVE_THRESHOLD = 10;
+
   const color = useMemo(() => {
     if (opened && mime && clickedMime) {
       return mimeColor;
@@ -97,12 +104,46 @@ function Square({
   );
 
   const handleTap = useCallback(() => {
+    if (longPressTriggered.current) return;
     onSelect(coOrd, "click");
   }, [coOrd, onSelect]);
 
   const handleDblTap = useCallback(() => {
     onDoubleClick(coOrd, "dblclick");
   }, [coOrd, onDoubleClick]);
+
+  const handleTouchStart = useCallback(
+    (e: KonvaEventObject<TouchEvent>) => {
+      const touch = e.evt.touches[0];
+      if (!touch) return;
+      touchStartPos.current = { x: touch.clientX, y: touch.clientY };
+      longPressTriggered.current = false;
+
+      longPressTimer.current = setTimeout(() => {
+        longPressTriggered.current = true;
+        onRightClick(coOrd, "contextmenu");
+      }, LONG_PRESS_DURATION);
+    },
+    [coOrd, onRightClick],
+  );
+
+  const handleTouchMove = useCallback((e: KonvaEventObject<TouchEvent>) => {
+    if (!touchStartPos.current || !longPressTimer.current) return;
+    const touch = e.evt.touches[0];
+    const dx = Math.abs(touch.clientX - touchStartPos.current.x);
+    const dy = Math.abs(touch.clientY - touchStartPos.current.y);
+    if (dx > MOVE_THRESHOLD || dy > MOVE_THRESHOLD) {
+      clearTimeout(longPressTimer.current);
+      longPressTimer.current = null;
+    }
+  }, []);
+
+  const handleTouchEnd = useCallback(() => {
+    if (longPressTimer.current) {
+      clearTimeout(longPressTimer.current);
+      longPressTimer.current = null;
+    }
+  }, []);
 
   return (
     <Group
@@ -111,6 +152,9 @@ function Square({
       onDblClick={handleDblClick}
       onTap={handleTap}
       onDblTap={handleDblTap}
+      onTouchStart={handleTouchStart}
+      onTouchMove={handleTouchMove}
+      onTouchEnd={handleTouchEnd}
     >
       <Rect
         x={x}

--- a/src/gameReducer.spec.ts
+++ b/src/gameReducer.spec.ts
@@ -37,6 +37,7 @@ describe("gameReducer", () => {
         type: "START_GAME",
         boardSize: GridSize.L,
         numMimes: MimeSize.L,
+        squareSide: 25,
       });
 
       expect(result.boardSize).toBe(GridSize.L);
@@ -48,6 +49,7 @@ describe("gameReducer", () => {
         type: "START_GAME",
         boardSize: GridSize.M,
         numMimes: MimeSize.M,
+        squareSide: 25,
       });
 
       expect(result.numFlags).toBe(MimeSize.M);
@@ -63,6 +65,7 @@ describe("gameReducer", () => {
         type: "START_GAME",
         boardSize: GridSize.S,
         numMimes: MimeSize.S,
+        squareSide: 25,
       });
 
       expect(result.playTime).toBe(0);
@@ -78,6 +81,7 @@ describe("gameReducer", () => {
         type: "START_GAME",
         boardSize: GridSize.S,
         numMimes: MimeSize.S,
+        squareSide: 25,
       });
 
       expect(result.numOpenSpaces).toBe(0);
@@ -93,6 +97,7 @@ describe("gameReducer", () => {
         type: "START_GAME",
         boardSize: GridSize.S,
         numMimes: MimeSize.S,
+        squareSide: 25,
       });
 
       expect(result.status).toBe("waitingStart");
@@ -103,6 +108,7 @@ describe("gameReducer", () => {
         type: "START_GAME",
         boardSize: GridSize.S,
         numMimes: MimeSize.S,
+        squareSide: 25,
       });
 
       expect(result.score).toBe(1000);
@@ -113,6 +119,7 @@ describe("gameReducer", () => {
         type: "START_GAME",
         boardSize: GridSize.M,
         numMimes: MimeSize.M,
+        squareSide: 25,
       });
 
       expect(result.score).toBe(6000);
@@ -123,6 +130,7 @@ describe("gameReducer", () => {
         type: "START_GAME",
         boardSize: GridSize.L,
         numMimes: MimeSize.L,
+        squareSide: 25,
       });
 
       expect(result.score).toBe(11000);
@@ -133,6 +141,7 @@ describe("gameReducer", () => {
         type: "START_GAME",
         boardSize: GridSize.XL,
         numMimes: MimeSize.XL,
+        squareSide: 25,
       });
 
       expect(result.score).toBe(16000);
@@ -184,6 +193,18 @@ describe("gameReducer", () => {
       const result = gameReducer(state, { type: "INIT_BOARD" });
 
       expect(result).toBe(state);
+    });
+
+    test("INIT_BOARD uses squareSide from state", () => {
+      const startState = gameReducer(initialState, {
+        type: "START_GAME",
+        boardSize: GridSize.S,
+        numMimes: MimeSize.S,
+        squareSide: 35,
+      });
+      const result = gameReducer(startState, { type: "INIT_BOARD" });
+      const square = result.game?.get("1|0" as Coordinate);
+      expect(square?.x).toBe(35); // 1 * 35
     });
   });
 

--- a/src/gameReducer.spec.ts
+++ b/src/gameReducer.spec.ts
@@ -152,7 +152,10 @@ describe("gameReducer", () => {
     test("creates game when status is waitingStart", () => {
       const newGameSpy = vi.spyOn(gameLogic, "newGame");
 
-      const result = gameReducer(initialState, { type: "INIT_BOARD" });
+      const result = gameReducer(initialState, {
+        type: "INIT_BOARD",
+        squareSide: gameLogic.SQUARE_SIDE,
+      });
 
       expect(newGameSpy).toHaveBeenCalledWith(
         GridSize.S,
@@ -168,7 +171,10 @@ describe("gameReducer", () => {
         game: createTestBoard(2),
       };
 
-      const result = gameReducer(state, { type: "INIT_BOARD" });
+      const result = gameReducer(state, {
+        type: "INIT_BOARD",
+        squareSide: 25,
+      });
 
       expect(result).toBe(state);
     });
@@ -179,7 +185,10 @@ describe("gameReducer", () => {
         status: "gameOverWon",
       };
 
-      const result = gameReducer(state, { type: "INIT_BOARD" });
+      const result = gameReducer(state, {
+        type: "INIT_BOARD",
+        squareSide: 25,
+      });
 
       expect(result).toBe(state);
     });
@@ -190,19 +199,25 @@ describe("gameReducer", () => {
         status: "gameOverLost",
       };
 
-      const result = gameReducer(state, { type: "INIT_BOARD" });
+      const result = gameReducer(state, {
+        type: "INIT_BOARD",
+        squareSide: 25,
+      });
 
       expect(result).toBe(state);
     });
 
-    test("INIT_BOARD uses squareSide from state", () => {
+    test("INIT_BOARD uses squareSide from action", () => {
       const startState = gameReducer(initialState, {
         type: "START_GAME",
         boardSize: GridSize.S,
         numMimes: MimeSize.S,
+        squareSide: 25,
+      });
+      const result = gameReducer(startState, {
+        type: "INIT_BOARD",
         squareSide: 35,
       });
-      const result = gameReducer(startState, { type: "INIT_BOARD" });
       const square = result.game?.get("1|0" as Coordinate);
       expect(square?.x).toBe(35); // 1 * 35
     });

--- a/src/gameReducer.ts
+++ b/src/gameReducer.ts
@@ -31,7 +31,7 @@ export type GameAction =
       numMimes: MimeSize;
       squareSide: number;
     }
-  | { type: "INIT_BOARD" }
+  | { type: "INIT_BOARD"; squareSide: number }
   | { type: "SQUARE_CLICK"; coordinate: Coordinate }
   | { type: "SQUARE_DOUBLE_CLICK"; coordinate: Coordinate }
   | { type: "SQUARE_RIGHT_CLICK"; coordinate: Coordinate }
@@ -97,7 +97,8 @@ export function gameReducer(state: GameState, action: GameAction): GameState {
       }
       return {
         ...state,
-        game: newGame(state.boardSize, state.squareSide),
+        squareSide: action.squareSide,
+        game: newGame(state.boardSize, action.squareSide),
       };
     }
 

--- a/src/gameReducer.ts
+++ b/src/gameReducer.ts
@@ -21,10 +21,16 @@ export interface GameState {
   playTime: number;
   score: number;
   showRules: boolean;
+  squareSide: number;
 }
 
 export type GameAction =
-  | { type: "START_GAME"; boardSize: GridSize; numMimes: MimeSize }
+  | {
+      type: "START_GAME";
+      boardSize: GridSize;
+      numMimes: MimeSize;
+      squareSide: number;
+    }
   | { type: "INIT_BOARD" }
   | { type: "SQUARE_CLICK"; coordinate: Coordinate }
   | { type: "SQUARE_DOUBLE_CLICK"; coordinate: Coordinate }
@@ -42,6 +48,7 @@ export const initialState: GameState = {
   playTime: 0,
   score: 0,
   showRules: false,
+  squareSide: SQUARE_SIDE,
 };
 
 function cloneGame(
@@ -81,6 +88,7 @@ export function gameReducer(state: GameState, action: GameAction): GameState {
         numOpenSpaces: 0,
         playTime: 0,
         score: getBaseScore(action.boardSize),
+        squareSide: action.squareSide,
       };
 
     case "INIT_BOARD": {
@@ -89,7 +97,7 @@ export function gameReducer(state: GameState, action: GameAction): GameState {
       }
       return {
         ...state,
-        game: newGame(state.boardSize, SQUARE_SIDE),
+        game: newGame(state.boardSize, state.squareSide),
       };
     }
 

--- a/src/hooks/useWindowSize.spec.ts
+++ b/src/hooks/useWindowSize.spec.ts
@@ -1,0 +1,54 @@
+import { act, renderHook } from "@testing-library/react";
+import { useWindowSize } from "./useWindowSize";
+
+describe("useWindowSize", () => {
+  const originalInnerWidth = window.innerWidth;
+  const originalInnerHeight = window.innerHeight;
+
+  afterEach(() => {
+    Object.defineProperty(window, "innerWidth", {
+      writable: true,
+      value: originalInnerWidth,
+    });
+    Object.defineProperty(window, "innerHeight", {
+      writable: true,
+      value: originalInnerHeight,
+    });
+  });
+
+  test("returns current window dimensions", () => {
+    Object.defineProperty(window, "innerWidth", {
+      writable: true,
+      value: 1024,
+    });
+    Object.defineProperty(window, "innerHeight", {
+      writable: true,
+      value: 768,
+    });
+
+    const { result } = renderHook(() => useWindowSize());
+
+    expect(result.current.width).toBe(1024);
+    expect(result.current.height).toBe(768);
+  });
+
+  test("updates on window resize", () => {
+    Object.defineProperty(window, "innerWidth", {
+      writable: true,
+      value: 1024,
+    });
+
+    const { result } = renderHook(() => useWindowSize());
+    expect(result.current.width).toBe(1024);
+
+    act(() => {
+      Object.defineProperty(window, "innerWidth", {
+        writable: true,
+        value: 375,
+      });
+      window.dispatchEvent(new Event("resize"));
+    });
+
+    expect(result.current.width).toBe(375);
+  });
+});

--- a/src/hooks/useWindowSize.ts
+++ b/src/hooks/useWindowSize.ts
@@ -1,0 +1,23 @@
+import { useEffect, useState } from "react";
+
+interface WindowSize {
+  width: number;
+  height: number;
+}
+
+export function useWindowSize(): WindowSize {
+  const [size, setSize] = useState<WindowSize>({
+    width: window.innerWidth,
+    height: window.innerHeight,
+  });
+
+  useEffect(() => {
+    function handleResize() {
+      setSize({ width: window.innerWidth, height: window.innerHeight });
+    }
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, []);
+
+  return size;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -8,10 +8,19 @@ body {
     sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  background: url("images/bg.jpg") white no-repeat;
-  background-size: cover;
-  background-position: center;
+  background: url("images/bg.jpg") center / cover no-repeat fixed;
+  background-color: #2a2a2e;
   overflow-x: hidden;
+  min-height: 100vh;
+}
+
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.35);
+  z-index: -1;
+  pointer-events: none;
 }
 
 code {

--- a/src/index.css
+++ b/src/index.css
@@ -9,6 +9,9 @@ body {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   background: url("images/bg.jpg") white no-repeat;
+  background-size: cover;
+  background-position: center;
+  overflow-x: hidden;
 }
 
 code {

--- a/src/utils/responsive.spec.ts
+++ b/src/utils/responsive.spec.ts
@@ -1,0 +1,49 @@
+import { computeSquareSide } from "./responsive";
+
+describe("computeSquareSide", () => {
+  test("fits squares to available width when possible", () => {
+    // 390px viewport, 16px padding each side, gridSize 10
+    // available = 390 - 32 = 358, 358 / 10 = 35.8 → floor = 35
+    const result = computeSquareSide(390, 10);
+    expect(result).toBe(35);
+  });
+
+  test("clamps to MIN_SQUARE_SIZE when computed size is too small", () => {
+    // 390px viewport, gridSize 30
+    // available = 358, 358 / 30 = 11.9 → floor = 11 → clamp to 28
+    const result = computeSquareSide(390, 30);
+    expect(result).toBe(28);
+  });
+
+  test("clamps to MAX_SQUARE_SIZE when viewport is very wide", () => {
+    // 2560px viewport, gridSize 10
+    // available = 2528, 2528 / 10 = 252.8 → floor = 252 → clamp to 40
+    const result = computeSquareSide(2560, 10);
+    expect(result).toBe(40);
+  });
+
+  test("returns MIN_SQUARE_SIZE for zero viewport", () => {
+    const result = computeSquareSide(0, 10);
+    expect(result).toBe(28);
+  });
+
+  test("handles typical mobile sizes", () => {
+    // iPhone SE: 375px, Small grid (10)
+    // available = 343, 343 / 10 = 34.3 → 34
+    expect(computeSquareSide(375, 10)).toBe(34);
+
+    // iPhone SE: 375px, Medium grid (20)
+    // available = 343, 343 / 20 = 17.15 → 17 → clamp to 28
+    expect(computeSquareSide(375, 20)).toBe(28);
+  });
+
+  test("handles typical desktop sizes", () => {
+    // 1440px desktop, Small grid (10)
+    // available = 1200 (max cap), 1200 / 10 = 120 → clamp to 40
+    expect(computeSquareSide(1440, 10)).toBe(40);
+
+    // 1440px desktop, XL grid (40)
+    // available = 1200, 1200 / 40 = 30
+    expect(computeSquareSide(1440, 40)).toBe(30);
+  });
+});

--- a/src/utils/responsive.ts
+++ b/src/utils/responsive.ts
@@ -1,0 +1,16 @@
+export const MIN_SQUARE_SIZE = 28;
+export const MAX_SQUARE_SIZE = 40;
+const CONTAINER_PADDING = 32; // 16px each side
+const MAX_BOARD_WIDTH = 1200;
+
+export function computeSquareSide(
+  viewportWidth: number,
+  gridSize: number,
+): number {
+  const available = Math.min(
+    Math.max(0, viewportWidth - CONTAINER_PADDING),
+    MAX_BOARD_WIDTH,
+  );
+  const computed = Math.floor(available / gridSize);
+  return Math.max(MIN_SQUARE_SIZE, Math.min(MAX_SQUARE_SIZE, computed));
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,7 +11,8 @@ export default defineConfig({
       overlay: { initialIsOpen: false },
       typescript: true,
       biome: {
-        command: "check",
+        command: "lint",
+        flags: "src/",
       },
     }),
     viteTsconfigPaths(),


### PR DESCRIPTION
## Summary
- Remove hard `min-width: 1000px` and replace with fluid responsive layout using media queries, `clamp()`, and CSS custom properties
- Add dynamic square sizing (`useWindowSize` hook + `computeSquareSide` utility) that auto-fits the game board to viewport width, clamped between 28px and 40px
- Implement long-press to flag on touch devices (500ms hold with 10px move cancellation threshold)
- Make modals full-screen on viewports below 1024px, with scrollable content
- Restructure header with semantic HTML (`<header>`, `<nav>`, `<h1>`) that stacks vertically on mobile
- Add board scroll container with touch-action support for larger boards on small screens
- Update "How to Play" instructions to include touch controls

## Test plan
- [ ] 243 tests passing with 97.93% statement coverage
- [ ] Verify on iPhone/Android: board fits viewport, squares are tappable (>= 28px)
- [ ] Verify long-press (500ms) toggles flag on mobile
- [ ] Verify modals are full-screen on mobile, centered card on desktop
- [ ] Verify header stacks vertically on narrow screens
- [ ] Verify difficulty buttons wrap to 2-column grid on mobile
- [ ] Verify horizontal scroll does not appear on any viewport width
- [ ] Verify desktop experience is unchanged at >= 1024px

🤖 Generated with [Claude Code](https://claude.com/claude-code)